### PR TITLE
Bump com.gradle.plugin-publish from 0.18.0 to 0.21.0

### DIFF
--- a/modules/gradle-plugin/build.gradle
+++ b/modules/gradle-plugin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
     id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.18.0'
+    id 'com.gradle.plugin-publish' version '0.21.0'
     id 'eclipse'
 }
 


### PR DESCRIPTION
Bumps com.gradle.plugin-publish from 0.18.0 to 0.21.0.

---
updated-dependencies:
- dependency-name: com.gradle.plugin-publish
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>