### PR TITLE
Type names in containers need to be resolved after conflict-renaming

### DIFF
--- a/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
@@ -31,6 +31,12 @@ public interface TypeArray extends TypeContainer {
         return "ArrayList";
     }
 
+    /** {@return the type name}
+    *
+    * Note that this needs to be resolved late (when accessed)
+    * and not when created. This ensures that conflict-renaming
+    * of the inner-type is reflected in the final type name. 
+    */
     @Override
     default TypeName typeName() {
         String innerName = innerType().wrapperTypeName().name();

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
@@ -23,9 +23,6 @@ public interface TypeArray extends TypeContainer {
         return ImmutableTypeArray.builder().typeNames(typeNames).innerType(innerType).build();
     }
 
-    /** {@return the type names instance} */
-    TypeNames typeNames();
-    
     @Override
     default String containerImplementation() {
         return "ArrayList";
@@ -35,7 +32,7 @@ public interface TypeArray extends TypeContainer {
     *
     * Note that this needs to be resolved late (when accessed)
     * and not when created. This ensures that conflict-renaming
-    * of the inner-type is reflected in the final type name. 
+    * of the inner-type is reflected in the final type name.
     */
     @Override
     default TypeName typeName() {

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeArray.java
@@ -20,14 +20,21 @@ public interface TypeArray extends TypeContainer {
      * @return an array type
      */
     static TypeArray of(TypeNames typeNames, Type innerType) {
-        String innerName = innerType.wrapperTypeName().name();
-        TypeName typeName = typeNames.of("List<" + innerName + ">");
-        return ImmutableTypeArray.builder().innerType(innerType).typeName(typeName).build();
+        return ImmutableTypeArray.builder().typeNames(typeNames).innerType(innerType).build();
     }
 
+    /** {@return the type names instance} */
+    TypeNames typeNames();
+    
     @Override
     default String containerImplementation() {
         return "ArrayList";
+    }
+
+    @Override
+    default TypeName typeName() {
+        String innerName = innerType().wrapperTypeName().name();
+        return typeNames().of("List<" + innerName + ">");
     }
 
     @Override

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeContainer.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeContainer.java
@@ -15,6 +15,9 @@ public interface TypeContainer extends Type {
     /** {@return the java implementation used to instantiate this container} */
     String containerImplementation();
 
+    /** {@return the type names instance} */
+    TypeNames typeNames();
+
     @Override
     default boolean isContainer() {
         return true;

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
@@ -36,6 +36,12 @@ public interface TypeMap extends TypeContainer {
         return "HashMap";
     }
 
+    /** {@return the type name}
+     *
+     * Note that this needs to be resolved late (when accessed)
+     * and not when created. This ensures that conflict-renaming
+     * of the inner-type is reflected in the final type name. 
+     */
     @Override
     default TypeName typeName() {
         String innerName = innerType().wrapperTypeName().name();

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
@@ -28,9 +28,6 @@ public interface TypeMap extends TypeContainer {
         return ImmutableTypeMap.builder().typeNames(typeNames).innerType(innerType).build();
     }
 
-    /** {@return the type names instance} */
-    TypeNames typeNames();
-
     @Override
     default String containerImplementation() {
         return "HashMap";
@@ -40,7 +37,7 @@ public interface TypeMap extends TypeContainer {
      *
      * Note that this needs to be resolved late (when accessed)
      * and not when created. This ensures that conflict-renaming
-     * of the inner-type is reflected in the final type name. 
+     * of the inner-type is reflected in the final type name.
      */
     @Override
     default TypeName typeName() {

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeMap.java
@@ -25,14 +25,21 @@ public interface TypeMap extends TypeContainer {
      * @return a new map-type.
      */
     static TypeMap of(TypeNames typeNames, Type innerType) {
-        String innerName = innerType.wrapperTypeName().name();
-        TypeName typeName = typeNames.of("Map<String, " + innerName + ">");
-        return ImmutableTypeMap.builder().innerType(innerType).typeName(typeName).build();
+        return ImmutableTypeMap.builder().typeNames(typeNames).innerType(innerType).build();
     }
+
+    /** {@return the type names instance} */
+    TypeNames typeNames();
 
     @Override
     default String containerImplementation() {
         return "HashMap";
+    }
+
+    @Override
+    default TypeName typeName() {
+        String innerName = innerType().wrapperTypeName().name();
+        return typeNames().of("Map<String, " + innerName + ">");
     }
 
     @Override

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
@@ -20,14 +20,21 @@ public interface TypeSet extends TypeContainer {
      * @return a set type
      */
     static TypeSet of(TypeNames typeNames, Type innerType) {
-        String innerName = innerType.wrapperTypeName().name();
-        TypeName typeName = typeNames.of("Set<" + innerName + ">");
-        return ImmutableTypeSet.builder().innerType(innerType).typeName(typeName).build();
+        return ImmutableTypeSet.builder().typeNames(typeNames).innerType(innerType).build();
     }
+
+    /** {@return the type names instance} */
+    TypeNames typeNames();
 
     @Override
     default String containerImplementation() {
         return "LinkedHashSet";
+    }
+
+    @Override
+    default TypeName typeName() {
+        String innerName = innerType().wrapperTypeName().name();
+        return typeNames().of("Set<" + innerName + ">");
     }
 
     @Override

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
@@ -31,6 +31,12 @@ public interface TypeSet extends TypeContainer {
         return "LinkedHashSet";
     }
 
+    /** {@return the type name}
+    *
+    * Note that this needs to be resolved late (when accessed)
+    * and not when created. This ensures that conflict-renaming
+    * of the inner-type is reflected in the final type name. 
+    */
     @Override
     default TypeName typeName() {
         String innerName = innerType().wrapperTypeName().name();

--- a/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
+++ b/src/main/java/dk/mada/jaxrs/model/types/TypeSet.java
@@ -23,9 +23,6 @@ public interface TypeSet extends TypeContainer {
         return ImmutableTypeSet.builder().typeNames(typeNames).innerType(innerType).build();
     }
 
-    /** {@return the type names instance} */
-    TypeNames typeNames();
-
     @Override
     default String containerImplementation() {
         return "LinkedHashSet";
@@ -35,7 +32,7 @@ public interface TypeSet extends TypeContainer {
     *
     * Note that this needs to be resolved late (when accessed)
     * and not when created. This ensures that conflict-renaming
-    * of the inner-type is reflected in the final type name. 
+    * of the inner-type is reflected in the final type name.
     */
     @Override
     default TypeName typeName() {

--- a/src/test/java/mada/fixture/TestIterator.java
+++ b/src/test/java/mada/fixture/TestIterator.java
@@ -45,7 +45,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "collisions_doc";
+        String testNameContains = "collisions";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));
         Predicate<? super Path> filterByProperty = p -> testDir.isEmpty() || p.toString().contains(testDir);

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/dto/CollisionAX.java
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/dto/CollisionAX.java
@@ -8,21 +8,38 @@
 
 package mada.tests.e2e.opts.parser.collisions_doc.dto;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * CollisionAX
+ * Note that A sorts alphabetically before a
  */
+@Schema(description = "Note that A sorts alphabetically before a")
 @JsonbPropertyOrder({
-  CollisionAX.JSON_PROPERTY_A_CAPITAL_BOOLEAN
+  CollisionAX.JSON_PROPERTY_A_CAPITAL_BOOLEAN,
+  CollisionAX.JSON_PROPERTY_A_CAPITAL_SET,
+  CollisionAX.JSON_PROPERTY_A_CAPITAL_MAP
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class CollisionAX {
   public static final String JSON_PROPERTY_A_CAPITAL_BOOLEAN = "aCapitalBoolean";
   @JsonbProperty(JSON_PROPERTY_A_CAPITAL_BOOLEAN)
   private Boolean aCapitalBoolean;
+
+  public static final String JSON_PROPERTY_A_CAPITAL_SET = "aCapitalSet";
+  @JsonbProperty(JSON_PROPERTY_A_CAPITAL_SET)
+  private Set<Collisiona> aCapitalSet = null;
+
+  public static final String JSON_PROPERTY_A_CAPITAL_MAP = "aCapitalMap";
+  @JsonbProperty(JSON_PROPERTY_A_CAPITAL_MAP)
+  private Map<String, Collisiona> aCapitalMap = null;
 
   public CollisionAX aCapitalBoolean(Boolean aCapitalBoolean) {
     this.aCapitalBoolean = aCapitalBoolean;
@@ -41,6 +58,58 @@ public class CollisionAX {
     this.aCapitalBoolean = aCapitalBoolean;
   }
 
+  public CollisionAX aCapitalSet(Set<Collisiona> aCapitalSet) {
+    this.aCapitalSet = aCapitalSet;
+    return this;
+  }
+
+  public CollisionAX addACapitalSetItem(Collisiona aCapitalSetItem) {
+    if (this.aCapitalSet == null) {
+      this.aCapitalSet = new LinkedHashSet<>();
+    }
+    this.aCapitalSet.add(aCapitalSetItem);
+    return this;
+  }
+
+  /**
+   * Get aCapitalSet
+   * @return aCapitalSet
+   **/
+  @Valid
+  public Set<Collisiona> getACapitalSet() {
+    return aCapitalSet;
+  }
+
+  public void setACapitalSet(Set<Collisiona> aCapitalSet) {
+    this.aCapitalSet = aCapitalSet;
+  }
+
+  public CollisionAX aCapitalMap(Map<String, Collisiona> aCapitalMap) {
+    this.aCapitalMap = aCapitalMap;
+    return this;
+  }
+
+  public CollisionAX putACapitalMapItem(String key, Collisiona aCapitalMapItem) {
+    if (this.aCapitalMap == null) {
+      this.aCapitalMap = new HashMap<>();
+    }
+    this.aCapitalMap.put(key, aCapitalMapItem);
+    return this;
+  }
+
+  /**
+   * Get aCapitalMap
+   * @return aCapitalMap
+   **/
+  @Valid
+  public Map<String, Collisiona> getACapitalMap() {
+    return aCapitalMap;
+  }
+
+  public void setACapitalMap(Map<String, Collisiona> aCapitalMap) {
+    this.aCapitalMap = aCapitalMap;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -50,12 +119,14 @@ public class CollisionAX {
       return false;
     }
     CollisionAX other = (CollisionAX) o;
-    return Objects.equals(this.aCapitalBoolean, other.aCapitalBoolean);
+    return Objects.equals(this.aCapitalBoolean, other.aCapitalBoolean) &&
+        Objects.equals(this.aCapitalSet, other.aCapitalSet) &&
+        Objects.equals(this.aCapitalMap, other.aCapitalMap);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(aCapitalBoolean);
+    return Objects.hash(aCapitalBoolean, aCapitalSet, aCapitalMap);
   }
 
   @Override
@@ -63,6 +134,8 @@ public class CollisionAX {
     StringBuilder sb = new StringBuilder();
     sb.append("class CollisionAX {");
     sb.append("\n    aCapitalBoolean: ").append(toIndentedString(aCapitalBoolean));
+    sb.append("\n    aCapitalSet: ").append(toIndentedString(aCapitalSet));
+    sb.append("\n    aCapitalMap: ").append(toIndentedString(aCapitalMap));
     sb.append("\n}");
     return sb.toString();
   }

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/dto/Collisiona.java
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/dto/Collisiona.java
@@ -8,21 +8,31 @@
 
 package mada.tests.e2e.opts.parser.collisions_doc.dto;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * Collisiona
+ * Make sure this appears before CollisionA in the document
  */
+@Schema(description = "Make sure this appears before CollisionA in the document")
 @JsonbPropertyOrder({
-  Collisiona.JSON_PROPERTY_A_BOOLEAN
+  Collisiona.JSON_PROPERTY_A_BOOLEAN,
+  Collisiona.JSON_PROPERTY_A_LIST
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class Collisiona {
   public static final String JSON_PROPERTY_A_BOOLEAN = "aBoolean";
   @JsonbProperty(JSON_PROPERTY_A_BOOLEAN)
   private Boolean aBoolean;
+
+  public static final String JSON_PROPERTY_A_LIST = "aList";
+  @JsonbProperty(JSON_PROPERTY_A_LIST)
+  private List<CollisionAX> aList = null;
 
   public Collisiona aBoolean(Boolean aBoolean) {
     this.aBoolean = aBoolean;
@@ -41,6 +51,32 @@ public class Collisiona {
     this.aBoolean = aBoolean;
   }
 
+  public Collisiona aList(List<CollisionAX> aList) {
+    this.aList = aList;
+    return this;
+  }
+
+  public Collisiona addAListItem(CollisionAX aListItem) {
+    if (this.aList == null) {
+      this.aList = new ArrayList<>();
+    }
+    this.aList.add(aListItem);
+    return this;
+  }
+
+  /**
+   * Get aList
+   * @return aList
+   **/
+  @Valid
+  public List<CollisionAX> getAList() {
+    return aList;
+  }
+
+  public void setAList(List<CollisionAX> aList) {
+    this.aList = aList;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -50,12 +86,13 @@ public class Collisiona {
       return false;
     }
     Collisiona other = (Collisiona) o;
-    return Objects.equals(this.aBoolean, other.aBoolean);
+    return Objects.equals(this.aBoolean, other.aBoolean) &&
+        Objects.equals(this.aList, other.aList);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(aBoolean);
+    return Objects.hash(aBoolean, aList);
   }
 
   @Override
@@ -63,6 +100,7 @@ public class Collisiona {
     StringBuilder sb = new StringBuilder();
     sb.append("class Collisiona {");
     sb.append("\n    aBoolean: ").append(toIndentedString(aBoolean));
+    sb.append("\n    aList: ").append(toIndentedString(aList));
     sb.append("\n}");
     return sb.toString();
   }

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/openapi.yaml
@@ -42,7 +42,7 @@ components:
           items:
             $ref: '#/components/schemas/CollisionA'
     CollisionA:
-      description: Note that A sorts alphabetially before a
+      description: Note that A sorts alphabetically before a
       type: object
       properties:
         aCapitalBoolean:
@@ -51,6 +51,10 @@ components:
           uniqueItems: true
           type: array
           items:
+            $ref: '#/components/schemas/Collisiona'
+        aCapitalMap:
+          type: object
+          additionalProperties:
             $ref: '#/components/schemas/Collisiona'
     Collisions:
       type: object

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_doc/openapi.yaml
@@ -30,17 +30,28 @@ paths:
                 $ref: '#/components/schemas/Collisions'
 components:
   schemas:
-    # Note A sorts before a
+    # Note: Collisiona moved manually before CollisionA
     Collisiona:
+      description: Make sure this appears before CollisionA in the document
       type: object
       properties:
         aBoolean:
           type: boolean
+        aList:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollisionA'
     CollisionA:
+      description: Note that A sorts alphabetially before a
       type: object
       properties:
         aCapitalBoolean:
           type: boolean
+        aCapitalSet:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Collisiona'
     Collisions:
       type: object
       properties:

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_name/dto/CollisionA.java
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_name/dto/CollisionA.java
@@ -8,21 +8,38 @@
 
 package mada.tests.e2e.opts.parser.collisions_name.dto;
 
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * CollisionA
+ * Note that A sorts alphabetically before a
  */
+@Schema(description = "Note that A sorts alphabetically before a")
 @JsonbPropertyOrder({
-  CollisionA.JSON_PROPERTY_A_CAPITAL_BOOLEAN
+  CollisionA.JSON_PROPERTY_A_CAPITAL_BOOLEAN,
+  CollisionA.JSON_PROPERTY_A_CAPITAL_SET,
+  CollisionA.JSON_PROPERTY_A_CAPITAL_MAP
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class CollisionA {
   public static final String JSON_PROPERTY_A_CAPITAL_BOOLEAN = "aCapitalBoolean";
   @JsonbProperty(JSON_PROPERTY_A_CAPITAL_BOOLEAN)
   private Boolean aCapitalBoolean;
+
+  public static final String JSON_PROPERTY_A_CAPITAL_SET = "aCapitalSet";
+  @JsonbProperty(JSON_PROPERTY_A_CAPITAL_SET)
+  private Set<CollisionaX> aCapitalSet = null;
+
+  public static final String JSON_PROPERTY_A_CAPITAL_MAP = "aCapitalMap";
+  @JsonbProperty(JSON_PROPERTY_A_CAPITAL_MAP)
+  private Map<String, CollisionaX> aCapitalMap = null;
 
   public CollisionA aCapitalBoolean(Boolean aCapitalBoolean) {
     this.aCapitalBoolean = aCapitalBoolean;
@@ -41,6 +58,58 @@ public class CollisionA {
     this.aCapitalBoolean = aCapitalBoolean;
   }
 
+  public CollisionA aCapitalSet(Set<CollisionaX> aCapitalSet) {
+    this.aCapitalSet = aCapitalSet;
+    return this;
+  }
+
+  public CollisionA addACapitalSetItem(CollisionaX aCapitalSetItem) {
+    if (this.aCapitalSet == null) {
+      this.aCapitalSet = new LinkedHashSet<>();
+    }
+    this.aCapitalSet.add(aCapitalSetItem);
+    return this;
+  }
+
+  /**
+   * Get aCapitalSet
+   * @return aCapitalSet
+   **/
+  @Valid
+  public Set<CollisionaX> getACapitalSet() {
+    return aCapitalSet;
+  }
+
+  public void setACapitalSet(Set<CollisionaX> aCapitalSet) {
+    this.aCapitalSet = aCapitalSet;
+  }
+
+  public CollisionA aCapitalMap(Map<String, CollisionaX> aCapitalMap) {
+    this.aCapitalMap = aCapitalMap;
+    return this;
+  }
+
+  public CollisionA putACapitalMapItem(String key, CollisionaX aCapitalMapItem) {
+    if (this.aCapitalMap == null) {
+      this.aCapitalMap = new HashMap<>();
+    }
+    this.aCapitalMap.put(key, aCapitalMapItem);
+    return this;
+  }
+
+  /**
+   * Get aCapitalMap
+   * @return aCapitalMap
+   **/
+  @Valid
+  public Map<String, CollisionaX> getACapitalMap() {
+    return aCapitalMap;
+  }
+
+  public void setACapitalMap(Map<String, CollisionaX> aCapitalMap) {
+    this.aCapitalMap = aCapitalMap;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -50,12 +119,14 @@ public class CollisionA {
       return false;
     }
     CollisionA other = (CollisionA) o;
-    return Objects.equals(this.aCapitalBoolean, other.aCapitalBoolean);
+    return Objects.equals(this.aCapitalBoolean, other.aCapitalBoolean) &&
+        Objects.equals(this.aCapitalSet, other.aCapitalSet) &&
+        Objects.equals(this.aCapitalMap, other.aCapitalMap);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(aCapitalBoolean);
+    return Objects.hash(aCapitalBoolean, aCapitalSet, aCapitalMap);
   }
 
   @Override
@@ -63,6 +134,8 @@ public class CollisionA {
     StringBuilder sb = new StringBuilder();
     sb.append("class CollisionA {");
     sb.append("\n    aCapitalBoolean: ").append(toIndentedString(aCapitalBoolean));
+    sb.append("\n    aCapitalSet: ").append(toIndentedString(aCapitalSet));
+    sb.append("\n    aCapitalMap: ").append(toIndentedString(aCapitalMap));
     sb.append("\n}");
     return sb.toString();
   }

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_name/dto/CollisionaX.java
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_name/dto/CollisionaX.java
@@ -8,21 +8,31 @@
 
 package mada.tests.e2e.opts.parser.collisions_name.dto;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
- * CollisionaX
+ * Make sure this appears before CollisionA in the document
  */
+@Schema(description = "Make sure this appears before CollisionA in the document")
 @JsonbPropertyOrder({
-  CollisionaX.JSON_PROPERTY_A_BOOLEAN
+  CollisionaX.JSON_PROPERTY_A_BOOLEAN,
+  CollisionaX.JSON_PROPERTY_A_LIST
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class CollisionaX {
   public static final String JSON_PROPERTY_A_BOOLEAN = "aBoolean";
   @JsonbProperty(JSON_PROPERTY_A_BOOLEAN)
   private Boolean aBoolean;
+
+  public static final String JSON_PROPERTY_A_LIST = "aList";
+  @JsonbProperty(JSON_PROPERTY_A_LIST)
+  private List<CollisionA> aList = null;
 
   public CollisionaX aBoolean(Boolean aBoolean) {
     this.aBoolean = aBoolean;
@@ -41,6 +51,32 @@ public class CollisionaX {
     this.aBoolean = aBoolean;
   }
 
+  public CollisionaX aList(List<CollisionA> aList) {
+    this.aList = aList;
+    return this;
+  }
+
+  public CollisionaX addAListItem(CollisionA aListItem) {
+    if (this.aList == null) {
+      this.aList = new ArrayList<>();
+    }
+    this.aList.add(aListItem);
+    return this;
+  }
+
+  /**
+   * Get aList
+   * @return aList
+   **/
+  @Valid
+  public List<CollisionA> getAList() {
+    return aList;
+  }
+
+  public void setAList(List<CollisionA> aList) {
+    this.aList = aList;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -50,12 +86,13 @@ public class CollisionaX {
       return false;
     }
     CollisionaX other = (CollisionaX) o;
-    return Objects.equals(this.aBoolean, other.aBoolean);
+    return Objects.equals(this.aBoolean, other.aBoolean) &&
+        Objects.equals(this.aList, other.aList);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(aBoolean);
+    return Objects.hash(aBoolean, aList);
   }
 
   @Override
@@ -63,6 +100,7 @@ public class CollisionaX {
     StringBuilder sb = new StringBuilder();
     sb.append("class CollisionaX {");
     sb.append("\n    aBoolean: ").append(toIndentedString(aBoolean));
+    sb.append("\n    aList: ").append(toIndentedString(aList));
     sb.append("\n}");
     return sb.toString();
   }

--- a/src/test/java/mada/tests/e2e/opts/parser/collisions_name/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/opts/parser/collisions_name/openapi.yaml
@@ -30,17 +30,32 @@ paths:
                 $ref: '#/components/schemas/Collisions'
 components:
   schemas:
-    # Note A sorts before a
+    # Note: Collisiona moved manually before CollisionA
     Collisiona:
+      description: Make sure this appears before CollisionA in the document
       type: object
       properties:
         aBoolean:
           type: boolean
+        aList:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollisionA'
     CollisionA:
+      description: Note that A sorts alphabetically before a
       type: object
       properties:
         aCapitalBoolean:
           type: boolean
+        aCapitalSet:
+          uniqueItems: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Collisiona'
+        aCapitalMap:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/Collisiona'
     Collisions:
       type: object
       properties:


### PR DESCRIPTION
#105 locked type names in containers at parsing time.

But conflict-renaming happens after all types are parsed. So delay access of inner-types in containers to later.
