### PR TITLE
Add @Schema to property enumerations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ javadoc {
 test {
     useJUnitPlatform()
 
-    systemProperty("run_all_tests", "false")
+    systemProperty("run_all_tests", "true")
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ javadoc {
 test {
     useJUnitPlatform()
 
-    systemProperty("run_all_tests", "true")
+    systemProperty("run_all_tests", "false")
     finalizedBy jacocoTestReport // report is always generated after tests run
 }
 

--- a/src/main/java/dk/mada/jaxrs/generator/dto/DtoGenerator.java
+++ b/src/main/java/dk/mada/jaxrs/generator/dto/DtoGenerator.java
@@ -456,6 +456,7 @@ public class DtoGenerator {
         String typeName = propType.wrapperTypeName().name();
         String enumClassName = typeName;
         String enumTypeName = typeName;
+        String enumSchema = null;
         boolean isContainer = isArray || isMap || isSet;
 
         if (getDereferencedInnerEnumType(innerType) instanceof TypeEnum te) {
@@ -464,6 +465,8 @@ public class DtoGenerator {
             enumClassName = te.typeName().name();
             ctxEnum = buildEnumEntries(te.innerType(), te.values());
             dtoImports.addEnumImports(!isContainer);
+
+            enumSchema = buildEnumSchema(dtoImports, innerType, ctxEnum);
 
             logger.debug(" enum {} : {}", innerTypeName, te.values());
         }
@@ -586,6 +589,7 @@ public class DtoGenerator {
                 .innerDatatypeWithEnum(innerTypeName)
                 .enumClassName(enumClassName)
                 .enumTypeName(enumTypeName)
+                .enumSchemaOptions(enumSchema)
                 .schemaOptions(schemaOptions)
                 .isUseBigDecimalForDouble(isUseBigDecimalForDouble)
                 .isUseEmptyCollections(isUseEmptyCollections)

--- a/src/main/java/dk/mada/jaxrs/generator/dto/DtoGenerator.java
+++ b/src/main/java/dk/mada/jaxrs/generator/dto/DtoGenerator.java
@@ -461,12 +461,13 @@ public class DtoGenerator {
 
         if (getDereferencedInnerEnumType(innerType) instanceof TypeEnum te) {
             isEnum = true;
-            enumTypeName = te.innerType().typeName().name();
+            Type enumType = te.innerType();
+            enumTypeName = enumType.typeName().name();
             enumClassName = te.typeName().name();
-            ctxEnum = buildEnumEntries(te.innerType(), te.values());
+            ctxEnum = buildEnumEntries(enumType, te.values());
             dtoImports.addEnumImports(!isContainer);
 
-            enumSchema = buildEnumSchema(dtoImports, innerType, ctxEnum);
+            enumSchema = buildEnumSchema(dtoImports, enumType, ctxEnum);
 
             logger.debug(" enum {} : {}", innerTypeName, te.values());
         }

--- a/src/main/java/dk/mada/jaxrs/generator/dto/tmpl/CtxPropertyExt.java
+++ b/src/main/java/dk/mada/jaxrs/generator/dto/tmpl/CtxPropertyExt.java
@@ -40,6 +40,10 @@ public interface CtxPropertyExt {
     @Nullable
     String enumTypeName();
 
+    /** {@return the schema options for an inline enumeration type, or null} */
+    @Nullable
+    String enumSchemaOptions();
+
     /** {@return the schema options (for use in @Schema), or null} */
     @Nullable
     String schemaOptions();

--- a/src/main/resources/templates/enumClass.mustache
+++ b/src/main/resources/templates/enumClass.mustache
@@ -3,6 +3,9 @@
    * {{description}}
    */
 {{/description}}
+  {{#madaProp.enumSchemaOptions}}
+  @Schema({{{madaProp.enumSchemaOptions}}})
+  {{/madaProp.enumSchemaOptions}}
   public enum {{{madaProp.enumClassName}}} {
         {{#allowableValues}}
             {{#enumVars}}

--- a/src/test/java/mada/fixture/TestIterator.java
+++ b/src/test/java/mada/fixture/TestIterator.java
@@ -45,7 +45,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "dto/enums";
+        String testNameContains = "";
 //        String testNameContains = "generator/bigde";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));

--- a/src/test/java/mada/fixture/TestIterator.java
+++ b/src/test/java/mada/fixture/TestIterator.java
@@ -45,7 +45,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "dto/validat";
+        String testNameContains = "dto/enums/jsonb";
 //        String testNameContains = "generator/bigde";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));

--- a/src/test/java/mada/fixture/TestIterator.java
+++ b/src/test/java/mada/fixture/TestIterator.java
@@ -45,7 +45,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "dto/enums/jsonb";
+        String testNameContains = "dto/enums";
 //        String testNameContains = "generator/bigde";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));

--- a/src/test/java/mada/tests/e2e/dto/enums/inner/dto/ManualInnerEnumDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/inner/dto/ManualInnerEnumDto.java
@@ -13,6 +13,8 @@ import javax.json.bind.adapter.JsonbAdapter;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -77,6 +79,7 @@ public class ManualInnerEnumDto {
   @Schema(description = "This selects transport form.\nEMAIL = this is an email\nSMS : this is an SMS")
   private StringTypeEnum stringType;
 
+  @Schema(enumeration = {"1", "2"}, type = SchemaType.INTEGER, format = "int32")
   public enum NumberTypeEnum {
     NUMBER_1(1),
     NUMBER_2(2);

--- a/src/test/java/mada/tests/e2e/dto/enums/inner/dto/ManualInnerEnumDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/inner/dto/ManualInnerEnumDto.java
@@ -13,7 +13,6 @@ import javax.json.bind.adapter.JsonbAdapter;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
-
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
@@ -12,6 +12,7 @@ import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * EnumsDto
@@ -29,6 +30,7 @@ import org.codehaus.jackson.annotate.JsonValue;
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class EnumsDto {
+  @Schema(enumeration = {"O", "M", "nexT"})
   public enum PropertyEnumStringEnum {
     O("O"),
     M("M"),

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
@@ -12,6 +12,7 @@ import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -30,7 +31,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class EnumsDto {
-  @Schema(enumeration = {"O", "M", "nexT"})
+  @Schema(enumeration = {"O", "M", "nexT"}, type = SchemaType.STRING)
   public enum PropertyEnumStringEnum {
     O("O"),
     M("M"),

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/EnumsDto.java
@@ -19,7 +19,11 @@ import org.codehaus.jackson.annotate.JsonValue;
 @JsonPropertyOrder({
   EnumsDto.JSON_PROPERTY_PROPERTY_ENUM_STRING,
   EnumsDto.JSON_PROPERTY_INNER,
+  EnumsDto.JSON_PROPERTY_LOWER,
+  EnumsDto.JSON_PROPERTY_MIXED,
   EnumsDto.JSON_PROPERTY_EXTERNAL,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_LOWER,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_MIXED,
   EnumsDto.JSON_PROPERTY_INTEGER_ENUM,
   EnumsDto.JSON_PROPERTY_STRING_INTEGER_ENUM
 })
@@ -27,7 +31,8 @@ import org.codehaus.jackson.annotate.JsonValue;
 public class EnumsDto {
   public enum PropertyEnumStringEnum {
     O("O"),
-    M("M");
+    M("M"),
+    NEXT("nexT");
 
     private final String value;
 
@@ -64,9 +69,25 @@ public class EnumsDto {
   @JsonProperty(JSON_PROPERTY_INNER)
   private InnerEnum inner;
 
+  public static final String JSON_PROPERTY_LOWER = "lower";
+  @JsonProperty(JSON_PROPERTY_LOWER)
+  private InnerLowerEnum lower;
+
+  public static final String JSON_PROPERTY_MIXED = "mixed";
+  @JsonProperty(JSON_PROPERTY_MIXED)
+  private InnerMixedEnum mixed;
+
   public static final String JSON_PROPERTY_EXTERNAL = "external";
   @JsonProperty(JSON_PROPERTY_EXTERNAL)
   private ExternalEnum external;
+
+  public static final String JSON_PROPERTY_EXTERNAL_LOWER = "externalLower";
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_LOWER)
+  private ExternalLowerEnum externalLower;
+
+  public static final String JSON_PROPERTY_EXTERNAL_MIXED = "externalMixed";
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_MIXED)
+  private ExternalMixedEnum externalMixed;
 
   public static final String JSON_PROPERTY_INTEGER_ENUM = "integerEnum";
   @JsonProperty(JSON_PROPERTY_INTEGER_ENUM)
@@ -111,6 +132,42 @@ public class EnumsDto {
     this.inner = inner;
   }
 
+  public EnumsDto lower(InnerLowerEnum lower) {
+    this.lower = lower;
+    return this;
+  }
+
+  /**
+   * Get lower
+   * @return lower
+   **/
+  @Valid
+  public InnerLowerEnum getLower() {
+    return lower;
+  }
+
+  public void setLower(InnerLowerEnum lower) {
+    this.lower = lower;
+  }
+
+  public EnumsDto mixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+    return this;
+  }
+
+  /**
+   * Get mixed
+   * @return mixed
+   **/
+  @Valid
+  public InnerMixedEnum getMixed() {
+    return mixed;
+  }
+
+  public void setMixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+  }
+
   public EnumsDto external(ExternalEnum external) {
     this.external = external;
     return this;
@@ -127,6 +184,42 @@ public class EnumsDto {
 
   public void setExternal(ExternalEnum external) {
     this.external = external;
+  }
+
+  public EnumsDto externalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+    return this;
+  }
+
+  /**
+   * Get externalLower
+   * @return externalLower
+   **/
+  @Valid
+  public ExternalLowerEnum getExternalLower() {
+    return externalLower;
+  }
+
+  public void setExternalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+  }
+
+  public EnumsDto externalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
+    return this;
+  }
+
+  /**
+   * Get externalMixed
+   * @return externalMixed
+   **/
+  @Valid
+  public ExternalMixedEnum getExternalMixed() {
+    return externalMixed;
+  }
+
+  public void setExternalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
   }
 
   public EnumsDto integerEnum(IntEnum integerEnum) {
@@ -176,14 +269,18 @@ public class EnumsDto {
     EnumsDto other = (EnumsDto) o;
     return Objects.equals(this.propertyEnumString, other.propertyEnumString) &&
         Objects.equals(this.inner, other.inner) &&
+        Objects.equals(this.lower, other.lower) &&
+        Objects.equals(this.mixed, other.mixed) &&
         Objects.equals(this.external, other.external) &&
+        Objects.equals(this.externalLower, other.externalLower) &&
+        Objects.equals(this.externalMixed, other.externalMixed) &&
         Objects.equals(this.integerEnum, other.integerEnum) &&
         Objects.equals(this.stringIntegerEnum, other.stringIntegerEnum);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(propertyEnumString, inner, external, integerEnum, stringIntegerEnum);
+    return Objects.hash(propertyEnumString, inner, lower, mixed, external, externalLower, externalMixed, integerEnum, stringIntegerEnum);
   }
 
   @Override
@@ -192,7 +289,11 @@ public class EnumsDto {
     sb.append("class EnumsDto {");
     sb.append("\n    propertyEnumString: ").append(toIndentedString(propertyEnumString));
     sb.append("\n    inner: ").append(toIndentedString(inner));
+    sb.append("\n    lower: ").append(toIndentedString(lower));
+    sb.append("\n    mixed: ").append(toIndentedString(mixed));
     sb.append("\n    external: ").append(toIndentedString(external));
+    sb.append("\n    externalLower: ").append(toIndentedString(externalLower));
+    sb.append("\n    externalMixed: ").append(toIndentedString(externalMixed));
     sb.append("\n    integerEnum: ").append(toIndentedString(integerEnum));
     sb.append("\n    stringIntegerEnum: ").append(toIndentedString(stringIntegerEnum));
     sb.append("\n}");

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/ExternalLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/ExternalLowerEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_codehaus.dto;
+
+import java.util.Objects;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalLowerEnum
+ */
+@Schema(enumeration = {"low_ext_a", "low_ext_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalLowerEnum {
+  LOW_EXT_A("low_ext_a"),
+  LOW_EXT_B("low_ext_b");
+
+  private final String value;
+
+  ExternalLowerEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ExternalLowerEnum fromValue(String value) {
+    for (ExternalLowerEnum b : ExternalLowerEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/ExternalMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/ExternalMixedEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_codehaus.dto;
+
+import java.util.Objects;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalMixedEnum
+ */
+@Schema(enumeration = {"low_EXT_a", "low_ext_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalMixedEnum {
+  LOW_EXT_A("low_EXT_a"),
+  LOW_EXT_B("low_ext_B");
+
+  private final String value;
+
+  ExternalMixedEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ExternalMixedEnum fromValue(String value) {
+    for (ExternalMixedEnum b : ExternalMixedEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/InnerLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/InnerLowerEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_codehaus.dto;
+
+import java.util.Objects;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerLowerEnum
+ */
+@Schema(enumeration = {"lower_a", "lower_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerLowerEnum {
+  LOWER_A("lower_a"),
+  LOWER_B("lower_b");
+
+  private final String value;
+
+  InnerLowerEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static InnerLowerEnum fromValue(String value) {
+    for (InnerLowerEnum b : InnerLowerEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/InnerMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/dto/InnerMixedEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_codehaus.dto;
+
+import java.util.Objects;
+import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonValue;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerMixedEnum
+ */
+@Schema(enumeration = {"MIXED_a", "mixed_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerMixedEnum {
+  MIXED_A("MIXED_a"),
+  MIXED_B("mixed_B");
+
+  private final String value;
+
+  InnerMixedEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static InnerMixedEnum fromValue(String value) {
+    for (InnerMixedEnum b : InnerMixedEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_codehaus/openapi.yaml
@@ -24,11 +24,20 @@ components:
           enum:
           - O
           - M
+          - nexT
           type: string
         inner:
           $ref: '#/components/schemas/InnerEnum'
+        lower:
+          $ref: '#/components/schemas/InnerLowerEnum'
+        mixed:
+          $ref: '#/components/schemas/InnerMixedEnum'
         external:
           $ref: '#/components/schemas/ExternalEnum'
+        externalLower:
+          $ref: '#/components/schemas/ExternalLowerEnum'
+        externalMixed:
+          $ref: '#/components/schemas/ExternalMixedEnum'
         integerEnum:
           $ref: '#/components/schemas/IntEnum'
         stringIntegerEnum:
@@ -38,10 +47,30 @@ components:
       - E
       - F
       type: string
+    ExternalLowerEnum:
+      enum:
+      - low_ext_a
+      - low_ext_b
+      type: string
+    ExternalMixedEnum:
+      enum:
+      - low_EXT_a
+      - low_ext_B
+      type: string
     InnerEnum:
       enum:
       - I
       - J
+      type: string
+    InnerLowerEnum:
+      enum:
+      - lower_a
+      - lower_b
+      type: string
+    InnerMixedEnum:
+      enum:
+      - MIXED_a
+      - mixed_B
       type: string
     IntEnum:
       format: int32

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/EnumsDto.java
@@ -19,7 +19,11 @@ import javax.validation.Valid;
 @JsonPropertyOrder({
   EnumsDto.JSON_PROPERTY_PROPERTY_ENUM_STRING,
   EnumsDto.JSON_PROPERTY_INNER,
+  EnumsDto.JSON_PROPERTY_LOWER,
+  EnumsDto.JSON_PROPERTY_MIXED,
   EnumsDto.JSON_PROPERTY_EXTERNAL,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_LOWER,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_MIXED,
   EnumsDto.JSON_PROPERTY_INTEGER_ENUM,
   EnumsDto.JSON_PROPERTY_STRING_INTEGER_ENUM
 })
@@ -27,7 +31,8 @@ import javax.validation.Valid;
 public class EnumsDto {
   public enum PropertyEnumStringEnum {
     O("O"),
-    M("M");
+    M("M"),
+    NEXT("nexT");
 
     private final String value;
 
@@ -64,9 +69,25 @@ public class EnumsDto {
   @JsonProperty(JSON_PROPERTY_INNER)
   private InnerEnum inner;
 
+  public static final String JSON_PROPERTY_LOWER = "lower";
+  @JsonProperty(JSON_PROPERTY_LOWER)
+  private InnerLowerEnum lower;
+
+  public static final String JSON_PROPERTY_MIXED = "mixed";
+  @JsonProperty(JSON_PROPERTY_MIXED)
+  private InnerMixedEnum mixed;
+
   public static final String JSON_PROPERTY_EXTERNAL = "external";
   @JsonProperty(JSON_PROPERTY_EXTERNAL)
   private ExternalEnum external;
+
+  public static final String JSON_PROPERTY_EXTERNAL_LOWER = "externalLower";
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_LOWER)
+  private ExternalLowerEnum externalLower;
+
+  public static final String JSON_PROPERTY_EXTERNAL_MIXED = "externalMixed";
+  @JsonProperty(JSON_PROPERTY_EXTERNAL_MIXED)
+  private ExternalMixedEnum externalMixed;
 
   public static final String JSON_PROPERTY_INTEGER_ENUM = "integerEnum";
   @JsonProperty(JSON_PROPERTY_INTEGER_ENUM)
@@ -111,6 +132,42 @@ public class EnumsDto {
     this.inner = inner;
   }
 
+  public EnumsDto lower(InnerLowerEnum lower) {
+    this.lower = lower;
+    return this;
+  }
+
+  /**
+   * Get lower
+   * @return lower
+   **/
+  @Valid
+  public InnerLowerEnum getLower() {
+    return lower;
+  }
+
+  public void setLower(InnerLowerEnum lower) {
+    this.lower = lower;
+  }
+
+  public EnumsDto mixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+    return this;
+  }
+
+  /**
+   * Get mixed
+   * @return mixed
+   **/
+  @Valid
+  public InnerMixedEnum getMixed() {
+    return mixed;
+  }
+
+  public void setMixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+  }
+
   public EnumsDto external(ExternalEnum external) {
     this.external = external;
     return this;
@@ -127,6 +184,42 @@ public class EnumsDto {
 
   public void setExternal(ExternalEnum external) {
     this.external = external;
+  }
+
+  public EnumsDto externalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+    return this;
+  }
+
+  /**
+   * Get externalLower
+   * @return externalLower
+   **/
+  @Valid
+  public ExternalLowerEnum getExternalLower() {
+    return externalLower;
+  }
+
+  public void setExternalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+  }
+
+  public EnumsDto externalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
+    return this;
+  }
+
+  /**
+   * Get externalMixed
+   * @return externalMixed
+   **/
+  @Valid
+  public ExternalMixedEnum getExternalMixed() {
+    return externalMixed;
+  }
+
+  public void setExternalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
   }
 
   public EnumsDto integerEnum(IntEnum integerEnum) {
@@ -176,14 +269,18 @@ public class EnumsDto {
     EnumsDto other = (EnumsDto) o;
     return Objects.equals(this.propertyEnumString, other.propertyEnumString) &&
         Objects.equals(this.inner, other.inner) &&
+        Objects.equals(this.lower, other.lower) &&
+        Objects.equals(this.mixed, other.mixed) &&
         Objects.equals(this.external, other.external) &&
+        Objects.equals(this.externalLower, other.externalLower) &&
+        Objects.equals(this.externalMixed, other.externalMixed) &&
         Objects.equals(this.integerEnum, other.integerEnum) &&
         Objects.equals(this.stringIntegerEnum, other.stringIntegerEnum);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(propertyEnumString, inner, external, integerEnum, stringIntegerEnum);
+    return Objects.hash(propertyEnumString, inner, lower, mixed, external, externalLower, externalMixed, integerEnum, stringIntegerEnum);
   }
 
   @Override
@@ -192,7 +289,11 @@ public class EnumsDto {
     sb.append("class EnumsDto {");
     sb.append("\n    propertyEnumString: ").append(toIndentedString(propertyEnumString));
     sb.append("\n    inner: ").append(toIndentedString(inner));
+    sb.append("\n    lower: ").append(toIndentedString(lower));
+    sb.append("\n    mixed: ").append(toIndentedString(mixed));
     sb.append("\n    external: ").append(toIndentedString(external));
+    sb.append("\n    externalLower: ").append(toIndentedString(externalLower));
+    sb.append("\n    externalMixed: ").append(toIndentedString(externalMixed));
     sb.append("\n    integerEnum: ").append(toIndentedString(integerEnum));
     sb.append("\n    stringIntegerEnum: ").append(toIndentedString(stringIntegerEnum));
     sb.append("\n}");

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/EnumsDto.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Objects;
 import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * EnumsDto
@@ -29,6 +31,7 @@ import javax.validation.Valid;
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class EnumsDto {
+  @Schema(enumeration = {"O", "M", "nexT"}, type = SchemaType.STRING)
   public enum PropertyEnumStringEnum {
     O("O"),
     M("M"),

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/ExternalLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/ExternalLowerEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_fasterxml.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalLowerEnum
+ */
+@Schema(enumeration = {"low_ext_a", "low_ext_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalLowerEnum {
+  LOW_EXT_A("low_ext_a"),
+  LOW_EXT_B("low_ext_b");
+
+  private final String value;
+
+  ExternalLowerEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ExternalLowerEnum fromValue(String value) {
+    for (ExternalLowerEnum b : ExternalLowerEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/ExternalMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/ExternalMixedEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_fasterxml.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalMixedEnum
+ */
+@Schema(enumeration = {"low_EXT_a", "low_ext_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalMixedEnum {
+  LOW_EXT_A("low_EXT_a"),
+  LOW_EXT_B("low_ext_B");
+
+  private final String value;
+
+  ExternalMixedEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ExternalMixedEnum fromValue(String value) {
+    for (ExternalMixedEnum b : ExternalMixedEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/InnerLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/InnerLowerEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_fasterxml.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerLowerEnum
+ */
+@Schema(enumeration = {"lower_a", "lower_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerLowerEnum {
+  LOWER_A("lower_a"),
+  LOWER_B("lower_b");
+
+  private final String value;
+
+  InnerLowerEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static InnerLowerEnum fromValue(String value) {
+    for (InnerLowerEnum b : InnerLowerEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/InnerMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/dto/InnerMixedEnum.java
@@ -1,0 +1,49 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jackson_fasterxml.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Objects;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerMixedEnum
+ */
+@Schema(enumeration = {"MIXED_a", "mixed_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerMixedEnum {
+  MIXED_A("MIXED_a"),
+  MIXED_B("mixed_B");
+
+  private final String value;
+
+  InnerMixedEnum(String value) {
+    this.value = value;
+  }
+
+  @JsonValue
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static InnerMixedEnum fromValue(String value) {
+    for (InnerMixedEnum b : InnerMixedEnum.values()) {
+      if (Objects.equals(b.value, value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/dto/enums/jackson_fasterxml/openapi.yaml
@@ -24,11 +24,20 @@ components:
           enum:
           - O
           - M
+          - nexT
           type: string
         inner:
           $ref: '#/components/schemas/InnerEnum'
+        lower:
+          $ref: '#/components/schemas/InnerLowerEnum'
+        mixed:
+          $ref: '#/components/schemas/InnerMixedEnum'
         external:
           $ref: '#/components/schemas/ExternalEnum'
+        externalLower:
+          $ref: '#/components/schemas/ExternalLowerEnum'
+        externalMixed:
+          $ref: '#/components/schemas/ExternalMixedEnum'
         integerEnum:
           $ref: '#/components/schemas/IntEnum'
         stringIntegerEnum:
@@ -38,10 +47,30 @@ components:
       - E
       - F
       type: string
+    ExternalLowerEnum:
+      enum:
+      - low_ext_a
+      - low_ext_b
+      type: string
+    ExternalMixedEnum:
+      enum:
+      - low_EXT_a
+      - low_ext_B
+      type: string
     InnerEnum:
       enum:
       - I
       - J
+      type: string
+    InnerLowerEnum:
+      enum:
+      - lower_a
+      - lower_b
+      type: string
+    InnerMixedEnum:
+      enum:
+      - MIXED_a
+      - mixed_B
       type: string
     IntEnum:
       format: int32

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
@@ -14,6 +14,7 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
 import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
  * EnumsDto
@@ -31,6 +32,7 @@ import javax.validation.Valid;
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class EnumsDto {
+  @Schema(enumeration = {"O", "M", "nexT"})
   public enum PropertyEnumStringEnum {
     O("O"),
     M("M"),

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
@@ -14,6 +14,7 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbPropertyOrder;
 import javax.json.bind.annotation.JsonbTypeAdapter;
 import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 /**
@@ -32,7 +33,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 })
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
 public class EnumsDto {
-  @Schema(enumeration = {"O", "M", "nexT"})
+  @Schema(enumeration = {"O", "M", "nexT"}, type = SchemaType.STRING)
   public enum PropertyEnumStringEnum {
     O("O"),
     M("M"),

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/EnumsDto.java
@@ -21,7 +21,11 @@ import javax.validation.Valid;
 @JsonbPropertyOrder({
   EnumsDto.JSON_PROPERTY_PROPERTY_ENUM_STRING,
   EnumsDto.JSON_PROPERTY_INNER,
+  EnumsDto.JSON_PROPERTY_LOWER,
+  EnumsDto.JSON_PROPERTY_MIXED,
   EnumsDto.JSON_PROPERTY_EXTERNAL,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_LOWER,
+  EnumsDto.JSON_PROPERTY_EXTERNAL_MIXED,
   EnumsDto.JSON_PROPERTY_INTEGER_ENUM,
   EnumsDto.JSON_PROPERTY_STRING_INTEGER_ENUM
 })
@@ -29,7 +33,8 @@ import javax.validation.Valid;
 public class EnumsDto {
   public enum PropertyEnumStringEnum {
     O("O"),
-    M("M");
+    M("M"),
+    NEXT("nexT");
 
     private final String value;
 
@@ -73,9 +78,25 @@ public class EnumsDto {
   @JsonbProperty(JSON_PROPERTY_INNER)
   private InnerEnum inner;
 
+  public static final String JSON_PROPERTY_LOWER = "lower";
+  @JsonbProperty(JSON_PROPERTY_LOWER)
+  private InnerLowerEnum lower;
+
+  public static final String JSON_PROPERTY_MIXED = "mixed";
+  @JsonbProperty(JSON_PROPERTY_MIXED)
+  private InnerMixedEnum mixed;
+
   public static final String JSON_PROPERTY_EXTERNAL = "external";
   @JsonbProperty(JSON_PROPERTY_EXTERNAL)
   private ExternalEnum external;
+
+  public static final String JSON_PROPERTY_EXTERNAL_LOWER = "externalLower";
+  @JsonbProperty(JSON_PROPERTY_EXTERNAL_LOWER)
+  private ExternalLowerEnum externalLower;
+
+  public static final String JSON_PROPERTY_EXTERNAL_MIXED = "externalMixed";
+  @JsonbProperty(JSON_PROPERTY_EXTERNAL_MIXED)
+  private ExternalMixedEnum externalMixed;
 
   public static final String JSON_PROPERTY_INTEGER_ENUM = "integerEnum";
   @JsonbProperty(JSON_PROPERTY_INTEGER_ENUM)
@@ -120,6 +141,42 @@ public class EnumsDto {
     this.inner = inner;
   }
 
+  public EnumsDto lower(InnerLowerEnum lower) {
+    this.lower = lower;
+    return this;
+  }
+
+  /**
+   * Get lower
+   * @return lower
+   **/
+  @Valid
+  public InnerLowerEnum getLower() {
+    return lower;
+  }
+
+  public void setLower(InnerLowerEnum lower) {
+    this.lower = lower;
+  }
+
+  public EnumsDto mixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+    return this;
+  }
+
+  /**
+   * Get mixed
+   * @return mixed
+   **/
+  @Valid
+  public InnerMixedEnum getMixed() {
+    return mixed;
+  }
+
+  public void setMixed(InnerMixedEnum mixed) {
+    this.mixed = mixed;
+  }
+
   public EnumsDto external(ExternalEnum external) {
     this.external = external;
     return this;
@@ -136,6 +193,42 @@ public class EnumsDto {
 
   public void setExternal(ExternalEnum external) {
     this.external = external;
+  }
+
+  public EnumsDto externalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+    return this;
+  }
+
+  /**
+   * Get externalLower
+   * @return externalLower
+   **/
+  @Valid
+  public ExternalLowerEnum getExternalLower() {
+    return externalLower;
+  }
+
+  public void setExternalLower(ExternalLowerEnum externalLower) {
+    this.externalLower = externalLower;
+  }
+
+  public EnumsDto externalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
+    return this;
+  }
+
+  /**
+   * Get externalMixed
+   * @return externalMixed
+   **/
+  @Valid
+  public ExternalMixedEnum getExternalMixed() {
+    return externalMixed;
+  }
+
+  public void setExternalMixed(ExternalMixedEnum externalMixed) {
+    this.externalMixed = externalMixed;
   }
 
   public EnumsDto integerEnum(IntEnum integerEnum) {
@@ -185,14 +278,18 @@ public class EnumsDto {
     EnumsDto other = (EnumsDto) o;
     return Objects.equals(this.propertyEnumString, other.propertyEnumString) &&
         Objects.equals(this.inner, other.inner) &&
+        Objects.equals(this.lower, other.lower) &&
+        Objects.equals(this.mixed, other.mixed) &&
         Objects.equals(this.external, other.external) &&
+        Objects.equals(this.externalLower, other.externalLower) &&
+        Objects.equals(this.externalMixed, other.externalMixed) &&
         Objects.equals(this.integerEnum, other.integerEnum) &&
         Objects.equals(this.stringIntegerEnum, other.stringIntegerEnum);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(propertyEnumString, inner, external, integerEnum, stringIntegerEnum);
+    return Objects.hash(propertyEnumString, inner, lower, mixed, external, externalLower, externalMixed, integerEnum, stringIntegerEnum);
   }
 
   @Override
@@ -201,7 +298,11 @@ public class EnumsDto {
     sb.append("class EnumsDto {");
     sb.append("\n    propertyEnumString: ").append(toIndentedString(propertyEnumString));
     sb.append("\n    inner: ").append(toIndentedString(inner));
+    sb.append("\n    lower: ").append(toIndentedString(lower));
+    sb.append("\n    mixed: ").append(toIndentedString(mixed));
     sb.append("\n    external: ").append(toIndentedString(external));
+    sb.append("\n    externalLower: ").append(toIndentedString(externalLower));
+    sb.append("\n    externalMixed: ").append(toIndentedString(externalMixed));
     sb.append("\n    integerEnum: ").append(toIndentedString(integerEnum));
     sb.append("\n    stringIntegerEnum: ").append(toIndentedString(stringIntegerEnum));
     sb.append("\n}");

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/ExternalLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/ExternalLowerEnum.java
@@ -1,0 +1,57 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jsonb.dto;
+
+import javax.json.Json;
+import javax.json.JsonString;
+import javax.json.bind.adapter.JsonbAdapter;
+import javax.json.bind.annotation.JsonbTypeAdapter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalLowerEnum
+ */
+@JsonbTypeAdapter(mada.tests.e2e.dto.enums.jsonb.dto.ExternalLowerEnum.ExternalLowerEnumAdapter.class)
+@Schema(enumeration = {"low_ext_a", "low_ext_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalLowerEnum {
+  LOW_EXT_A("low_ext_a"),
+  LOW_EXT_B("low_ext_b");
+
+  private final String value;
+
+  ExternalLowerEnum(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  public static class ExternalLowerEnumAdapter implements JsonbAdapter<ExternalLowerEnum, JsonString> {
+      @Override
+      public JsonString adaptToJson(ExternalLowerEnum e) throws Exception {
+          return Json.createValue(String.valueOf(e.value));
+      }
+
+      @Override
+      public ExternalLowerEnum adaptFromJson(JsonString value) throws Exception {
+          for (ExternalLowerEnum b : ExternalLowerEnum.values()) {
+              if (String.valueOf(b.value).equalsIgnoreCase(value.getString())) {
+                  return b;
+              }
+          }
+          throw new IllegalStateException("Unable to deserialize '" + value.getString() + "' to type ExternalLowerEnum");
+      }
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/ExternalMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/ExternalMixedEnum.java
@@ -1,0 +1,57 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jsonb.dto;
+
+import javax.json.Json;
+import javax.json.JsonString;
+import javax.json.bind.adapter.JsonbAdapter;
+import javax.json.bind.annotation.JsonbTypeAdapter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * ExternalMixedEnum
+ */
+@JsonbTypeAdapter(mada.tests.e2e.dto.enums.jsonb.dto.ExternalMixedEnum.ExternalMixedEnumAdapter.class)
+@Schema(enumeration = {"low_EXT_a", "low_ext_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum ExternalMixedEnum {
+  LOW_EXT_A("low_EXT_a"),
+  LOW_EXT_B("low_ext_B");
+
+  private final String value;
+
+  ExternalMixedEnum(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  public static class ExternalMixedEnumAdapter implements JsonbAdapter<ExternalMixedEnum, JsonString> {
+      @Override
+      public JsonString adaptToJson(ExternalMixedEnum e) throws Exception {
+          return Json.createValue(String.valueOf(e.value));
+      }
+
+      @Override
+      public ExternalMixedEnum adaptFromJson(JsonString value) throws Exception {
+          for (ExternalMixedEnum b : ExternalMixedEnum.values()) {
+              if (String.valueOf(b.value).equalsIgnoreCase(value.getString())) {
+                  return b;
+              }
+          }
+          throw new IllegalStateException("Unable to deserialize '" + value.getString() + "' to type ExternalMixedEnum");
+      }
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/InnerLowerEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/InnerLowerEnum.java
@@ -1,0 +1,57 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jsonb.dto;
+
+import javax.json.Json;
+import javax.json.JsonString;
+import javax.json.bind.adapter.JsonbAdapter;
+import javax.json.bind.annotation.JsonbTypeAdapter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerLowerEnum
+ */
+@JsonbTypeAdapter(mada.tests.e2e.dto.enums.jsonb.dto.InnerLowerEnum.InnerLowerEnumAdapter.class)
+@Schema(enumeration = {"lower_a", "lower_b"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerLowerEnum {
+  LOWER_A("lower_a"),
+  LOWER_B("lower_b");
+
+  private final String value;
+
+  InnerLowerEnum(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  public static class InnerLowerEnumAdapter implements JsonbAdapter<InnerLowerEnum, JsonString> {
+      @Override
+      public JsonString adaptToJson(InnerLowerEnum e) throws Exception {
+          return Json.createValue(String.valueOf(e.value));
+      }
+
+      @Override
+      public InnerLowerEnum adaptFromJson(JsonString value) throws Exception {
+          for (InnerLowerEnum b : InnerLowerEnum.values()) {
+              if (String.valueOf(b.value).equalsIgnoreCase(value.getString())) {
+                  return b;
+              }
+          }
+          throw new IllegalStateException("Unable to deserialize '" + value.getString() + "' to type InnerLowerEnum");
+      }
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/InnerMixedEnum.java
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/dto/InnerMixedEnum.java
@@ -1,0 +1,57 @@
+/*
+ * openapi-examples API
+ *
+ * The version of the OpenAPI document: 1.0.0-SNAPSHOT
+ */
+
+package mada.tests.e2e.dto.enums.jsonb.dto;
+
+import javax.json.Json;
+import javax.json.JsonString;
+import javax.json.bind.adapter.JsonbAdapter;
+import javax.json.bind.annotation.JsonbTypeAdapter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * InnerMixedEnum
+ */
+@JsonbTypeAdapter(mada.tests.e2e.dto.enums.jsonb.dto.InnerMixedEnum.InnerMixedEnumAdapter.class)
+@Schema(enumeration = {"MIXED_a", "mixed_B"}, type = SchemaType.STRING)
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum InnerMixedEnum {
+  MIXED_A("MIXED_a"),
+  MIXED_B("mixed_B");
+
+  private final String value;
+
+  InnerMixedEnum(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  public static class InnerMixedEnumAdapter implements JsonbAdapter<InnerMixedEnum, JsonString> {
+      @Override
+      public JsonString adaptToJson(InnerMixedEnum e) throws Exception {
+          return Json.createValue(String.valueOf(e.value));
+      }
+
+      @Override
+      public InnerMixedEnum adaptFromJson(JsonString value) throws Exception {
+          for (InnerMixedEnum b : InnerMixedEnum.values()) {
+              if (String.valueOf(b.value).equalsIgnoreCase(value.getString())) {
+                  return b;
+              }
+          }
+          throw new IllegalStateException("Unable to deserialize '" + value.getString() + "' to type InnerMixedEnum");
+      }
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/enums/jsonb/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/dto/enums/jsonb/openapi.yaml
@@ -24,11 +24,20 @@ components:
           enum:
           - O
           - M
+          - nexT
           type: string
         inner:
           $ref: '#/components/schemas/InnerEnum'
+        lower:
+          $ref: '#/components/schemas/InnerLowerEnum'
+        mixed:
+          $ref: '#/components/schemas/InnerMixedEnum'
         external:
           $ref: '#/components/schemas/ExternalEnum'
+        externalLower:
+          $ref: '#/components/schemas/ExternalLowerEnum'
+        externalMixed:
+          $ref: '#/components/schemas/ExternalMixedEnum'
         integerEnum:
           $ref: '#/components/schemas/IntEnum'
         stringIntegerEnum:
@@ -38,10 +47,30 @@ components:
       - E
       - F
       type: string
+    ExternalLowerEnum:
+      enum:
+      - low_ext_a
+      - low_ext_b
+      type: string
+    ExternalMixedEnum:
+      enum:
+      - low_EXT_a
+      - low_ext_B
+      type: string
     InnerEnum:
       enum:
       - I
       - J
+      type: string
+    InnerLowerEnum:
+      enum:
+      - lower_a
+      - lower_b
+      type: string
+    InnerMixedEnum:
+      enum:
+      - MIXED_a
+      - mixed_B
       type: string
     IntEnum:
       format: int32


### PR DESCRIPTION
The enumerations for down-stream clients would have been all upper-case (matching the Java enumeration constants).

This change adds  @<!-- -->Schema annotations to in-line enumerations in the DTO (used only for a single property), restoring their external wire-values to those provided by the up-stream service.
