### PR TITLE
Handle Quarkus 3 output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ javadoc {
 }
 
 test {
-    testLogging.showStandardStreams = true
+    //testLogging.showStandardStreams = true
     
     inputs.files(fileTree(dir: "src/test/java", include: "**/openapi.yaml, **/test.properties"))
 

--- a/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
+++ b/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
@@ -212,10 +212,18 @@ public final class TypeConverter {
      * @return the found reference or null
      */
     @Nullable private ParserTypeRef createPrimitiveTypeRef(RefInfo ri) {
+        // If the property declares a primitive type *and* allOf is defined
+        // (as happens from Quarkus 3) ignore the found primitive. It is not
+        // the full story.
+        if (ri.schema.getAllOf() != null) {
+            return null;
+        }
+
         Type type = Primitive.find(ri.schema);
         if (type == null) {
             return null;
         }
+
         List<?> enumeration = ri.schema.getEnum();
         if (enumeration == null || ri.propertyName == null) {
             String name = type.typeName().name();
@@ -319,6 +327,7 @@ public final class TypeConverter {
         if (ri.schema instanceof ComposedSchema cs) {
             @SuppressWarnings("rawtypes")
             List<Schema> allOf = cs.getAllOf();
+
             if (allOf != null && !allOf.isEmpty()) {
 
                 logger.info("PROCESSING allOf:");

--- a/src/test/java/mada/fixture/TestIterator.java
+++ b/src/test/java/mada/fixture/TestIterator.java
@@ -47,7 +47,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "plain_object";
+        String testNameContains = "allof_single";
 //        String testNameContains = "oneof_co";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));

--- a/src/test/java/mada/tests/e2e/dto/allof_single/README.txt
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/README.txt
@@ -1,0 +1,27 @@
+Quarkus 3+ generates new output when fields are annotated with @Schema such as:
+
+# Quarkus 3
+    DtoE:
+      required:
+      - member-in-E
+      type: object
+      properties:
+        member-in-E:
+          description: enum in E
+          type: string
+          allOf:
+          - $ref: '#/components/schemas/EnumDescription'
+
+# Quarkus 2
+    DtoE:
+      required:
+      - member-in-E
+      type: object
+      properties:
+        member-in-E:
+          allOf:
+          - $ref: '#/components/schemas/EnumDescription'
+          - description: enum in E
+
+
+Looks the same in editor.swagger.io.

--- a/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoA.java
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoA.java
@@ -1,0 +1,119 @@
+/*
+ * jboss-helloworld
+ *
+ * The version of the OpenAPI document: 1.0
+ */
+
+package mada.tests.e2e.dto.allof_single.dto;
+
+import java.util.Objects;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * DtoA
+ */
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public class DtoA {
+  public static final String JSON_PROPERTY_MEMBER_A = "memberA";
+  @JsonbProperty(JSON_PROPERTY_MEMBER_A)
+  private Boolean memberA;
+
+  public static final String JSON_PROPERTY_REF_B = "refB";
+  @JsonbProperty(JSON_PROPERTY_REF_B)
+  @Schema(description = "ref to object")
+  private DtoB refB;
+
+  public static final String JSON_PROPERTY_REF_E = "refE";
+  @JsonbProperty(JSON_PROPERTY_REF_E)
+  private DtoE refE;
+
+  public DtoA memberA(Boolean memberA) {
+    this.memberA = memberA;
+    return this;
+  }
+
+  /**
+   * Get memberA
+   * @return memberA
+   **/
+  public Boolean isMemberA() {
+    return memberA;
+  }
+
+  public void setMemberA(Boolean memberA) {
+    this.memberA = memberA;
+  }
+
+  public DtoA refB(DtoB refB) {
+    this.refB = refB;
+    return this;
+  }
+
+  /**
+   * ref to object.
+   *
+   * @return refB
+   **/
+  @Valid
+  public DtoB getRefB() {
+    return refB;
+  }
+
+  public void setRefB(DtoB refB) {
+    this.refB = refB;
+  }
+
+  public DtoA refE(DtoE refE) {
+    this.refE = refE;
+    return this;
+  }
+
+  /**
+   * Get refE
+   * @return refE
+   **/
+  @Valid
+  public DtoE getRefE() {
+    return refE;
+  }
+
+  public void setRefE(DtoE refE) {
+    this.refE = refE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DtoA)) {
+      return false;
+    }
+    DtoA other = (DtoA) o;
+    return Objects.equals(this.memberA, other.memberA) &&
+        Objects.equals(this.refB, other.refB) &&
+        Objects.equals(this.refE, other.refE);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(memberA, refB, refE);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DtoA {");
+    sb.append("\n    memberA: ").append(toIndentedString(memberA));
+    sb.append("\n    refB: ").append(toIndentedString(refB));
+    sb.append("\n    refE: ").append(toIndentedString(refE));
+    sb.append("\n}");
+    return sb.toString();
+  }
+
+  private String toIndentedString(Object o) {
+    return Objects.toString(o).replace("\n", "\n    ");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoB.java
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoB.java
@@ -1,0 +1,67 @@
+/*
+ * jboss-helloworld
+ *
+ * The version of the OpenAPI document: 1.0
+ */
+
+package mada.tests.e2e.dto.allof_single.dto;
+
+import java.util.Objects;
+import javax.json.bind.annotation.JsonbProperty;
+
+/**
+ * DtoB
+ */
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public class DtoB {
+  public static final String JSON_PROPERTY_MEMBER_B = "memberB";
+  @JsonbProperty(JSON_PROPERTY_MEMBER_B)
+  private Integer memberB;
+
+  public DtoB memberB(Integer memberB) {
+    this.memberB = memberB;
+    return this;
+  }
+
+  /**
+   * Get memberB
+   * @return memberB
+   **/
+  public Integer getMemberB() {
+    return memberB;
+  }
+
+  public void setMemberB(Integer memberB) {
+    this.memberB = memberB;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DtoB)) {
+      return false;
+    }
+    DtoB other = (DtoB) o;
+    return Objects.equals(this.memberB, other.memberB);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(memberB);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DtoB {");
+    sb.append("\n    memberB: ").append(toIndentedString(memberB));
+    sb.append("\n}");
+    return sb.toString();
+  }
+
+  private String toIndentedString(Object o) {
+    return Objects.toString(o).replace("\n", "\n    ");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoE.java
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoE.java
@@ -1,0 +1,74 @@
+/*
+ * jboss-helloworld
+ *
+ * The version of the OpenAPI document: 1.0
+ */
+
+package mada.tests.e2e.dto.allof_single.dto;
+
+import java.util.Objects;
+import javax.json.bind.annotation.JsonbProperty;
+import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import mada.tests.e2e.opts.generator.schema_naming.dto.EnumDescription;
+
+/**
+ * DtoE
+ */
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public class DtoE {
+  public static final String JSON_PROPERTY_MEMBER_IN_E = "member-in-E";
+  @JsonbProperty(JSON_PROPERTY_MEMBER_IN_E)
+  @Schema(required = true, description = "enum in E")
+  private EnumDescription memberInE;
+
+  public DtoE memberInE(EnumDescription memberInE) {
+    this.memberInE = Objects.requireNonNull(memberInE, "Property memberInE is required, cannot be null");
+    return this;
+  }
+
+  /**
+   * enum in E.
+   *
+   * @return memberInE
+   **/
+  @NotNull
+  public EnumDescription getMemberInE() {
+    return memberInE;
+  }
+
+  public void setMemberInE(EnumDescription memberInE) {
+    this.memberInE = Objects.requireNonNull(memberInE, "Property memberInE is required, cannot be null");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DtoE)) {
+      return false;
+    }
+    DtoE other = (DtoE) o;
+    return Objects.equals(this.memberInE, other.memberInE);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(memberInE);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DtoE {");
+    sb.append("\n    memberInE: ").append(toIndentedString(memberInE));
+    sb.append("\n}");
+    return sb.toString();
+  }
+
+  private String toIndentedString(Object o) {
+    return Objects.toString(o).replace("\n", "\n    ");
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoE.java
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/dto/DtoE.java
@@ -8,10 +8,9 @@ package mada.tests.e2e.dto.allof_single.dto;
 
 import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-
-import mada.tests.e2e.opts.generator.schema_naming.dto.EnumDescription;
 
 /**
  * DtoE
@@ -33,7 +32,7 @@ public class DtoE {
    *
    * @return memberInE
    **/
-  @NotNull
+  @NotNull @Valid
   public EnumDescription getMemberInE() {
     return memberInE;
   }

--- a/src/test/java/mada/tests/e2e/dto/allof_single/dto/EnumDescription.java
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/dto/EnumDescription.java
@@ -1,0 +1,57 @@
+/*
+ * jboss-helloworld
+ *
+ * The version of the OpenAPI document: 1.0
+ */
+
+package mada.tests.e2e.dto.allof_single.dto;
+
+import javax.json.Json;
+import javax.json.JsonString;
+import javax.json.bind.adapter.JsonbAdapter;
+import javax.json.bind.annotation.JsonbTypeAdapter;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * an enum.
+ */
+@JsonbTypeAdapter(mada.tests.e2e.dto.allof_single.dto.EnumDescription.EnumDescriptionAdapter.class)
+@Schema(description = "an enum")
+@javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
+public enum EnumDescription {
+  VALUE_A("VALUE_A"),
+  VALUE_B("VALUE_B"),
+  VALUE_C("VALUE_C");
+
+  private final String value;
+
+  EnumDescription(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  public static class EnumDescriptionAdapter implements JsonbAdapter<EnumDescription, JsonString> {
+      @Override
+      public JsonString adaptToJson(EnumDescription e) throws Exception {
+          return Json.createValue(String.valueOf(e.value));
+      }
+
+      @Override
+      public EnumDescription adaptFromJson(JsonString value) throws Exception {
+          for (EnumDescription b : EnumDescription.values()) {
+              if (String.valueOf(b.value).equalsIgnoreCase(value.getString())) {
+                  return b;
+              }
+          }
+          throw new IllegalStateException("Unable to deserialize '" + value.getString() + "' to type EnumDescription");
+      }
+  }
+}

--- a/src/test/java/mada/tests/e2e/dto/allof_single/openapi.yaml
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/openapi.yaml
@@ -1,0 +1,60 @@
+---
+openapi: 3.0.3
+info:
+  title: jboss-helloworld
+  version: "1.0"
+servers:
+- url: /jboss-helloworld
+paths:
+  /services/tests:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DtoA'
+components:
+  schemas:
+    DtoA:
+      type: object
+      properties:
+        memberA:
+          type: boolean
+        refB:
+          description: ref to object
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/DtoB'
+        refE:
+          type: object
+          allOf:
+          - $ref: '#/components/schemas/DtoE'
+          deprecated: true
+    DtoB:
+      type: object
+      properties:
+        memberB:
+          format: int32
+          type: integer
+    DtoE:
+      required:
+      - member-in-E
+      type: object
+      properties:
+        member-in-E:
+          description: enum in E
+          type: string
+          allOf:
+          - $ref: '#/components/schemas/EnumDescription'
+    EnumDescription:
+      description: an enum
+      enum:
+      - VALUE_A
+      - VALUE_B
+      - VALUE_C
+      type: string
+  

--- a/src/test/java/mada/tests/e2e/dto/allof_single/test.properties
+++ b/src/test/java/mada/tests/e2e/dto/allof_single/test.properties
@@ -1,0 +1,1 @@
+test-skip-api-comparison=true


### PR DESCRIPTION
smallrye-openapi in Quarkus 3 moves an allOf-target's type (and schema parts) up to the property.

Quarkus 2:
```yaml
      properties:
        member-in-E:
          allOf:
          - $ref: '#/components/schemas/EnumDescription'
          - description: enum in E
```

Quarkus 3:
```yaml
      properties:
        member-in-E:
          description: enum in E
          type: string
          allOf:
          - $ref: '#/components/schemas/EnumDescription'
```

The parser would see the primitive type and be content.
This change makes the allOf take priority.
