### PR TITLE
Change download enabled to onlyIf

### DIFF
--- a/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/DownloadOpenApiDocument.java
+++ b/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/DownloadOpenApiDocument.java
@@ -38,6 +38,9 @@ public abstract class DownloadOpenApiDocument extends DefaultTask {
         // changed at any time - so it always needs to be downloaded when the task runs.
         // We assume the user knows when it is necessary to re-download the document.
         getOutputs().upToDateWhen(t -> false);
+
+        // But only download if the URL is actually specified.
+    	onlyIf(t -> getDocumentUrl().isPresent());
     }
 
     /**

--- a/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/DownloadOpenApiDocument.java
+++ b/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/DownloadOpenApiDocument.java
@@ -40,7 +40,7 @@ public abstract class DownloadOpenApiDocument extends DefaultTask {
         getOutputs().upToDateWhen(t -> false);
 
         // But only download if the URL is actually specified.
-    	onlyIf(t -> getDocumentUrl().isPresent());
+        onlyIf(t -> getDocumentUrl().isPresent());
     }
 
     /**

--- a/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/JaxrsPlugin.java
+++ b/modules/gradle-plugin/src/main/java/dk/mada/jaxrs/gradle/JaxrsPlugin.java
@@ -83,7 +83,6 @@ public class JaxrsPlugin implements Plugin<Project> {
 
                         t.setDescription("Downloads OpenApi document for client " + docName);
                         t.setGroup(CLIENT_TASK_GROUP);
-                        t.setEnabled(url.isPresent());
                         t.getDocumentUrl().set(url);
                         t.getOutputFile().set(extOpenApiDocDirectory.file(openapiDocumentName));
                     });


### PR DESCRIPTION
When the task is created the client DSL may - or may not - have been parsed, causing intermittent behavior.