### PR TITLE
Remove javadoc publishing

### DIFF
--- a/.github/workflows/publish-mavencentral.yaml
+++ b/.github/workflows/publish-mavencentral.yaml
@@ -152,11 +152,3 @@ jobs:
             && echo "Publish completed" \
             || echo "Publish skipped / failed"
           rm -f cookies.txt
-
-      - name: Deploy Javadoc
-        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e
-        # 4.5.0
-        with:
-          branch: gh-pages
-          folder: build/docs/javadoc
-          ssh-key: ${{ secrets.DEPLOY_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # An OpenAPI JAX-RS client code generator
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jskov_openapi-jaxrs-client&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jskov_openapi-jaxrs-client) [![Javadoc](https://img.shields.io/badge/JavaDoc-Online-green)](https://jskov.github.io/openapi-jaxrs-client/)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jskov_openapi-jaxrs-client&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jskov_openapi-jaxrs-client)
 
 Generates Java code to call REST services.
 


### PR DESCRIPTION
Need javadoc aggregate stuff removed just before 0.10.10 release.
But not sure there is a purpose at present.