### PR TITLE
Handle multiple OpenAPI specification versions

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -2,6 +2,13 @@
 * TypeLocalTime and TypeDateTime should be passive carriers of the type.
   Let the generator handle the java-specific implementations (make the model simpler, and more generic).
 
+# v31
+API:
+  * .../map
+    does not handle object inner types because of createSupplementalValidation
+  * /api/params/body/boolean-primitive
+    @NotNull on primitive
+
 # Others
 
 o Make options self-documenting

--- a/TODO.txt
+++ b/TODO.txt
@@ -8,6 +8,8 @@ API:
     does not handle object inner types because of createSupplementalValidation
   * /api/params/body/boolean-primitive
     @NotNull on primitive
+  * still a lot of instanceof in the TypeConverter so the "all" document used in the specs
+    tests must be woefully incomplete
 
 # Others
 

--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/Generator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/Generator.java
@@ -31,6 +31,7 @@ import dk.mada.jaxrs.utils.DirectoryDeleter;
 public final class Generator implements GeneratorService {
     /** Constructs new instance. */
     public Generator() {
+        // empty
     }
 
     @Override

--- a/modules/generator/src/test/java/mada/fixture/TestIterator.java
+++ b/modules/generator/src/test/java/mada/fixture/TestIterator.java
@@ -6,7 +6,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -51,8 +50,11 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
+        String testNameContains = "manual";
 //        String testNameContains = "dto/validation/a";
-        String testNameContains = "string_pattern";
+//        String testNameContains = "e2e/specs/v3_0";
+//        String testNameContains = "e2e/specs/v3_1/all";
+//        String testNameContains = "e2e/specs/v3_1/anyof";
 
         boolean runAllTests = Boolean.parseBoolean(System.getProperty("run_all_tests"));
         Predicate<? super Path> filterByProperty = p -> testDir.isEmpty() || p.toString().contains(testDir);
@@ -86,7 +88,7 @@ class TestIterator {
                         new EndToEndTester().runTest(OUTPUT_DIR, pkgPrefix, testRootDir, testOutputDir));
                 })
                 .sorted((a, b) -> a.getDisplayName().compareTo(b.getDisplayName()))
-                .collect(Collectors.toList());
+                .toList();
         }
     }
 }

--- a/modules/generator/src/test/resources/logging-test.properties
+++ b/modules/generator/src/test/resources/logging-test.properties
@@ -8,7 +8,7 @@ java.util.logging.SimpleFormatter.format=%1$tT %3$s [%4$s] %5$s %n%6$s%n
 .level= INFO
 mada.fixture.level = INFO
 // Set the below to FINE to see E2E stacktraces
-mada.fixture.EndToEndTester.level = FINE
+mada.fixture.EndToEndTester.level = INFO
 mada.test.level = INFO
 
 dk.mada.level = INFO

--- a/modules/generator/src/test/resources/logging-test.properties
+++ b/modules/generator/src/test/resources/logging-test.properties
@@ -8,7 +8,7 @@ java.util.logging.SimpleFormatter.format=%1$tT %3$s [%4$s] %5$s %n%6$s%n
 .level= INFO
 mada.fixture.level = INFO
 // Set the below to FINE to see E2E stacktraces
-mada.fixture.EndToEndTester.level = INFO
+mada.fixture.EndToEndTester.level = FINE
 mada.test.level = INFO
 
 dk.mada.level = INFO
@@ -28,6 +28,7 @@ dk.mada.jaxrs.model.naming.level = INFO
 dk.mada.jaxrs.openapi.level = INFO
 dk.mada.jaxrs.openapi.ApiTransformer.level = INFO
 dk.mada.jaxrs.openapi.DtoTransformer.level = INFO
+dk.mada.jaxrs.openapi.Parser.level = DEBUG
 dk.mada.jaxrs.openapi.ParserTypes.level = INFO
 dk.mada.jaxrs.openapi.Resolver.level = INFO
 dk.mada.jaxrs.openapi.TypeConverter.level = INFO

--- a/modules/model/src/main/java/dk/mada/jaxrs/model/types/Primitive.java
+++ b/modules/model/src/main/java/dk/mada/jaxrs/model/types/Primitive.java
@@ -6,6 +6,12 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Primitive types of the java language (plus String).
+ *
+ * There is https://swagger.io/specification/#data-types and there is https://spec.openapis.org/registry/format/ But
+ * Quarkus/smallrye-open-api implements formatted numbers as integers.
+ * https://github.com/smallrye/smallrye-open-api/pull/2128
+ * 
+ * So three combatants...
  */
 public enum Primitive implements Type {
     /** The boolean. */
@@ -16,14 +22,18 @@ public enum Primitive implements Type {
      * @see <a href="https://swagger.io/specification/#data-types">spec</a>
      */
     NOFORMAT_INT("integer:", TypeNames.MARKER_NOFORMAT_INT, TypeNames.MARKER_NOFORMAT_INT),
-    /** The byte. */
+    /** The byte via (legacy) https://swagger.io/specification/#data-types. */
     BYTE("string:byte", TypeNames.BYTE, TypeNames.BYTE_WRAPPER),
-    /**
-     * The short. This cannot be represented by spec's type/format.
-     *
-     * @see <a href="https://swagger.io/specification/#data-types">spec</a>
-     */
+    /** The byte via smallrye #2128. */
+    BYTE_INT("integer:int8", TypeNames.BYTE, TypeNames.BYTE_WRAPPER),
+    /** The byte via https://spec.openapis.org/registry/format/. */
+    BYTE_NUMBER("number:int8", TypeNames.BYTE, TypeNames.BYTE_WRAPPER),
+    /** The short - not mapped in legacy https://swagger.io/specification/#data-types. */
     SHORT("undef", TypeNames.SHORT, TypeNames.SHORT_WRAPPER),
+    /** The short via smallrye #2128. */
+    SHORT_INT("integer:int16", TypeNames.SHORT, TypeNames.SHORT_WRAPPER),
+    /** The byte via https://spec.openapis.org/registry/format/. */
+    SHORT_NUMBER("number:int16", TypeNames.SHORT, TypeNames.SHORT_WRAPPER),
     /** The integer. */
     INT("integer:int32", TypeNames.INTEGER, TypeNames.INTEGER_WRAPPER),
     /** The long. */

--- a/modules/model/src/main/java/dk/mada/jaxrs/model/types/Primitive.java
+++ b/modules/model/src/main/java/dk/mada/jaxrs/model/types/Primitive.java
@@ -10,7 +10,7 @@ import org.jspecify.annotations.Nullable;
  * There is https://swagger.io/specification/#data-types and there is https://spec.openapis.org/registry/format/ But
  * Quarkus/smallrye-open-api implements formatted numbers as integers.
  * https://github.com/smallrye/smallrye-open-api/pull/2128
- * 
+ *
  * So three combatants...
  */
 public enum Primitive implements Type {

--- a/modules/model/src/main/java/dk/mada/jaxrs/model/types/TypeLocalTime.java
+++ b/modules/model/src/main/java/dk/mada/jaxrs/model/types/TypeLocalTime.java
@@ -14,8 +14,10 @@ import org.jspecify.annotations.Nullable;
 public final class TypeLocalTime implements Type {
     /** The single instance of this object. */
     @Nullable private static TypeLocalTime instance;
-    /** The OpenApi custom format used for this type. */
-    public static final String OPENAPI_CUSTOM_FORMAT = "local-time";
+    /** The custom format from Quarkus. */
+    public static final String CUSTOM_TIME_FORMAT_QUARKUS = "local-time";
+    /** The OpenApi (not yet spec?) format from https://spec.openapis.org/registry/format/ */
+    public static final String TIME_FORMAT_OPENAPI = "time";
 
     private TypeLocalTime() {
     }

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/ApiTransformer.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/ApiTransformer.java
@@ -156,9 +156,9 @@ public class ApiTransformer {
         Optional<RequestBody> requestBody = getRequestBody(groupOperationId, resourcePath, op);
         requestBody.ifPresent(rb -> parameters.addAll(rb.formParameters()));
 
-        List<Response> responses;
+        List<Response> opResponses;
         if (op.getResponses() != null) {
-            responses = op.getResponses().entrySet().stream()
+            opResponses = op.getResponses().entrySet().stream()
                     .map(e -> {
                         String code = e.getKey();
                         ApiResponse resp = e.getValue();
@@ -166,7 +166,7 @@ public class ApiTransformer {
                     })
                     .toList();
         } else {
-            responses = List.of();
+            opResponses = List.of();
         }
 
         ops.add(Operation.builder()
@@ -178,7 +178,7 @@ public class ApiTransformer {
                 .syntheticOpId(syntheticOperationId)
                 .httpMethod(toModelHttpMethod(httpMethod))
                 .path(resourcePath)
-                .responses(responses)
+                .responses(opResponses)
                 .parameters(parameters)
                 .requestBody(requestBody)
                 .addAuthorizationHeader(shouldAddAuthHeader(op))
@@ -431,8 +431,6 @@ public class ApiTransformer {
                 ref = TypeVoid.getRef();
             } else {
                 @Nullable Schema<?> ss = getPreferredSchema(c, context);
-
-                logger.trace("SCHEMA: {}", ss);
 
                 if (ss == null) {
                     // This happens in some documents - and can be used to redirect to

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Parser.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Parser.java
@@ -109,6 +109,12 @@ public final class Parser {
             throw new IllegalStateException("No output from parsing document " + spec);
         }
 
+        List<String> parserMessages = result.getMessages();
+        if (parserMessages != null && !parserMessages.isEmpty()) {
+            logger.warn("Parser messages for {}:", spec);
+            parserMessages.forEach(s -> logger.warn(" {}", s));
+        }
+
         ParserTypes parserTypes = new ParserTypes(typeNames, parserOpts, leakedGenOpts);
         var typeConverter = new TypeConverter(typeNames, parserTypes, parserRefs, naming, parserOpts, leakedGenOpts);
 

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Resolver.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Resolver.java
@@ -500,7 +500,7 @@ public final class Resolver {
             resolvedValidation = resolvedRef.validation();
         } else if (resolvedValidation.required()) {
             // handle simple required_validation since it is simplest - and probably enough for now
-            resolvedValidation = Validations.required(resolvedRef.validation());
+            resolvedValidation = Validations.makeRequired(resolvedRef.validation());
         }
 
         // allOf constructed DTOs need to be able to deserialize subsets
@@ -511,7 +511,7 @@ public final class Resolver {
         Set<String> relaxProps = dtoPropertiesToBeRelaxed.get(parent.typeName());
         if (relaxProps != null && relaxProps.contains(propName)) {
             logger.trace("     + relaxing validation");
-            resolvedValidation = Validations.relax(resolvedValidation);
+            resolvedValidation = Validations.makeRelaxed(resolvedValidation);
         }
 
         // TODO: get example from type, see mada.tests.e2e.regression.string_pattern.dto.KlarTilBeslutningsGrundlagResponse

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParser.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParser.java
@@ -1,0 +1,150 @@
+package dk.mada.jaxrs.openapi;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
+import dk.mada.jaxrs.model.types.TypeLocalTime;
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * OpenApi Schema parser.
+ *
+ * Specifications are available at https://spec.openapis.org/
+ */
+public interface SchemaParser {
+    /** {@return the OpenApi schema this parser operates on} */
+    Schema<?> schema(); // NOSONAR
+
+    /** {@return the schema name, or null} */
+    default @Nullable String name() {
+        return schema().getName();
+    }
+
+    /** {@return the schema type, or null} */
+    @Nullable String type();
+
+    /** {@return the schema format, or null} */
+    @Nullable String format();
+
+    /** {@return the schema for the contained items} */
+    default Schema<?> itemsSchema() { // NOSONAR
+        return Objects.requireNonNull(schema().getItems(), "No type for nested items- guard by isArray");
+    }
+
+    /** {@return true if the schema defines a composition by anyOf} */
+    boolean isAnyOf();
+
+    /** {@return the anyOf schemas} */
+    @SuppressWarnings("rawtypes")
+    default List<Schema> anyOfSchemas() {
+        return Objects.requireNonNull(schema().getAnyOf(), "No anyOf schemas - guard by isAnyOf");
+    }
+
+    /** {@return true if the schema defines a composition by oneOf} */
+    boolean isOneOf();
+
+    /** {@return the oneOf schemas} */
+    @SuppressWarnings("rawtypes")
+    default List<Schema> oneOfSchemas() {
+        return Objects.requireNonNull(schema().getOneOf(), "No oneOf schemas - guard by isOneOf");
+    }
+
+    /** {@return true if the schema defines an array} */
+    boolean isArray();
+
+    /**
+     * {@return true if the schema defines a date}
+     *
+     * @param acceptBrokenType if true, allows null/date to be recognized as a date
+     */
+    boolean isDate(boolean acceptBrokenType);
+
+    /**
+     * {@return if the schema defines a date-time}
+     *
+     * @param acceptBrokenType if true, allows null/date-time to be recognized as a date-time
+     */
+    boolean isDateTime(boolean acceptBrokenType);
+
+    /** {@return true if the schema defines a map} */
+    boolean isMap();
+
+    /** {@return the schema defining the inner type of a map} */
+    @SuppressWarnings("rawtypes")
+    default Schema<?> mapInnerSchema() {
+        return (Schema<?>) schema().getAdditionalProperties();
+    }
+
+    /** {@return true if the type is nullable} */
+    boolean isNullable();
+
+    /** {@return true if the schema defines a number} */
+    boolean isNumber();
+
+    /** {@return true if the schema defines an object} */
+    boolean isObject();
+
+    /** {@return true if the schema contains a reference to another type} */
+    default boolean isRef() {
+        return schema().get$ref() != null;
+    }
+
+    /** {@return true if the schema defines a string} */
+    boolean isString();
+
+    /** {@return true if this schema defines (just) time} */
+    default boolean isTime() {
+        return isString()
+                && (TypeLocalTime.CUSTOM_TIME_FORMAT_QUARKUS.equals(format())
+                        || TypeLocalTime.TIME_FORMAT_OPENAPI.equals(format()));
+    }
+
+    /** {@return true if the schema defines unique items (is a set)} */
+    default boolean isUnique() {
+        Boolean isUnique = schema().getUniqueItems();
+        return isUnique != null && isUnique.booleanValue();
+    }
+
+    /**
+     * {@return true if this schema represents a combination of types}
+     *
+     * TODO: probably close to new array of types? TODO: rename, something like isCombinedType
+     */
+    default boolean isAllOf() {
+        return schema().getAllOf() != null;
+    }
+
+    /** {@return true if the schema is a binary stream of data} */
+    boolean isBinary();
+
+    /** {@return true if this schema defines an enumeration} */
+    default boolean isEnumeration() {
+        return schema().getEnum() != null;
+    }
+
+    /** {@return enumeration values} */
+    default List<String> enumerationValues() {
+        return Objects.requireNonNull(schema().getEnum(), "must guard call with isEnumeration()").stream()
+                .map(Objects::toString)
+                .toList();
+    }
+
+    /**
+     * {@return a parser suitable for the given schema}
+     *
+     * Uses the schema's specification version to determine the parser implementation to use.
+     *
+     * @param schema the schema to provide a parser for
+     */
+    static SchemaParser of(Schema<?> schema) {
+        SpecVersion specVersion = schema.getSpecVersion();
+        return switch (specVersion) {
+        case SpecVersion.V30 -> new SchemaParserV30(schema);
+        case SpecVersion.V31 -> new SchemaParserV31(schema);
+        default -> throw new IllegalStateException("Unhandled spec version " + specVersion);
+        };
+    }
+}

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParserV30.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParserV30.java
@@ -1,0 +1,113 @@
+package dk.mada.jaxrs.openapi;
+
+import org.jspecify.annotations.Nullable;
+
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BinarySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.DateSchema;
+import io.swagger.v3.oas.models.media.DateTimeSchema;
+import io.swagger.v3.oas.models.media.FileSchema;
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.NumberSchema;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+
+/**
+ * OpenApi V3.0.x parser details.
+ *
+ * https://spec.openapis.org/oas/v3.0.4.html (or newer from https://spec.openapis.org/)
+ */
+public final class SchemaParserV30 implements SchemaParser {
+    /** The schema being parsed. */
+    private final Schema<?> schema;
+
+    /**
+     * Creates new parser instance.
+     *
+     * @param schema the schema to parse
+     */
+    public SchemaParserV30(Schema<?> schema) {
+        this.schema = schema;
+    }
+
+    @Override
+    public Schema<?> schema() {
+        return schema;
+    }
+
+    @Override
+    public @Nullable String type() {
+        String schemaType = schema.getType();
+        if (schemaType == null) {
+            schemaType = schema.get$ref();
+        }
+        return schemaType;
+    }
+
+    @Override
+    public @Nullable String format() {
+        return schema.getFormat();
+    }
+
+    @Override
+    public boolean isArray() {
+        return schema instanceof ArraySchema;
+    }
+
+    @Override
+    public boolean isAnyOf() {
+        return schema instanceof ComposedSchema
+                && schema().getAnyOf() != null;
+    }
+
+    @Override
+    public boolean isOneOf() {
+        return schema instanceof ComposedSchema
+                && schema().getOneOf() != null;
+    }
+
+    @Override
+    public boolean isBinary() {
+        return schema instanceof BinarySchema || schema instanceof FileSchema;
+    }
+
+    @Override
+    public boolean isDate(boolean acceptBrokenType) {
+        return "date".equals(format())
+                && (acceptBrokenType || schema() instanceof DateSchema);
+    }
+
+    @Override
+    public boolean isDateTime(boolean acceptBrokenType) {
+        return "date-time".equals(format())
+                && (acceptBrokenType || schema() instanceof DateTimeSchema);
+    }
+
+    @Override
+    public boolean isMap() {
+        return schema instanceof MapSchema;
+    }
+
+    @Override
+    public boolean isNullable() {
+        Boolean nullable = schema.getNullable();
+        return nullable != null && nullable.booleanValue();
+    }
+
+    @Override
+    public boolean isNumber() {
+        return schema instanceof NumberSchema;
+    }
+
+    @Override
+    public boolean isObject() {
+        return schema instanceof ObjectSchema;
+    }
+
+    @Override
+    public boolean isString() {
+        return schema instanceof StringSchema;
+    }
+}

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParserV31.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/SchemaParserV31.java
@@ -1,0 +1,142 @@
+package dk.mada.jaxrs.openapi;
+
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import io.swagger.v3.oas.models.media.Schema;
+
+/**
+ * OpenApi V3.1.x parser details.
+ *
+ * https://spec.openapis.org/oas/v3.1.1.html (or newer from https://spec.openapis.org/)
+ */
+public final class SchemaParserV31 implements SchemaParser {
+    /** The schema being parsed. */
+    private final Schema<?> schema;
+    /** The schema type. */
+    private final @Nullable String type;
+    /** Flag for type's ability be null. */
+    private final boolean nullable;
+
+    /**
+     * Creates new parser instance.
+     *
+     * @param schema the schema to parse
+     */
+    public SchemaParserV31(Schema<?> schema) {
+        this.schema = schema;
+
+        // Instead of a flag for nullable, the V3.1 specification
+        // encodes this as an extra type element (e.g. non-nullable: [string], nullable: [string, null])
+        String schemaType;
+        Set<String> schemaTypes = schema.getTypes();
+
+        if (schemaTypes == null) {
+            // This is legacy behavior in mada parser/resolver. Probably not super...
+            schemaType = schema.get$ref();
+            nullable = false;
+        } else if (schemaTypes.size() == 1) {
+            schemaType = schemaTypes.iterator().next();
+            nullable = false;
+        } else if (schemaTypes.size() == 2 && schemaTypes.contains("null")) {
+            schemaType = schemaTypes.stream()
+                    .filter(s -> !"null".equals(s))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No non-null type?! " + schemaTypes));
+            nullable = true;
+        } else {
+            // see https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---OpenAPI-3.1
+            throw new IllegalStateException("The mada parser does not yet handle the array data types in " + schema);
+        }
+        type = schemaType;
+    }
+
+    @Override
+    public Schema<?> schema() {
+        return schema;
+    }
+
+    @Override
+    public @Nullable String type() {
+        return type;
+    }
+
+    @Override
+    public @Nullable String format() {
+        return schema.getFormat();
+    }
+
+    @Override
+    public boolean isArray() {
+        return schema().getItems() != null && isTypeArray();
+    }
+
+    // Note that there are two types:
+    // <ul>
+    // <li> /api/interfaces/super (object/anyOf)
+    // <li> /api/interfaces/list (array/anyOf)
+    @Override
+    public boolean isAnyOf() {
+        var anyOf = schema().getAnyOf();
+        return (anyOf != null && !anyOf.isEmpty() && (isTypeArray() || isObject()));
+    }
+
+    @Override
+    public boolean isOneOf() {
+        var oneOf = schema().getOneOf();
+        return (oneOf != null && !oneOf.isEmpty() && isObject());
+    }
+
+    @Override
+    public boolean isBinary() {
+        return "binary".equals(format()) && isString();
+    }
+
+    @Override
+    public boolean isDate(boolean acceptBrokenType) {
+        return "date".equals(format())
+                && (acceptBrokenType || isString());
+    }
+
+    @Override
+    public boolean isDateTime(boolean acceptBrokenType) {
+        return "date-time".equals(format())
+                && (acceptBrokenType || isString());
+    }
+
+    @Override
+    public boolean isMap() {
+        return schema.getAdditionalProperties() instanceof Schema<?>
+                && isObject();
+    }
+
+    @Override
+    public boolean isNullable() {
+        return nullable;
+    }
+
+    private boolean isTypeArray() {
+        return typesContainsJust("array");
+    }
+
+    @Override
+    public boolean isNumber() {
+        return typesContainsJust("number");
+    }
+
+    @Override
+    public boolean isObject() {
+        return typesContainsJust("object");
+    }
+
+    @Override
+    public boolean isString() {
+        return typesContainsJust("string");
+    }
+
+    private boolean typesContainsJust(String typeName) {
+        Set<String> types = schema.getTypes();
+        return types != null && types.size() == 1 && types.contains(typeName);
+    }
+}

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
@@ -42,18 +42,9 @@ import dk.mada.jaxrs.model.types.TypeSet;
 import dk.mada.jaxrs.model.types.TypeUUID;
 import dk.mada.jaxrs.model.types.TypeValidation;
 import dk.mada.jaxrs.openapi.Parser.LeakedGeneratorOpts;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.BinarySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.DateSchema;
-import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.Discriminator;
-import io.swagger.v3.oas.models.media.FileSchema;
-import io.swagger.v3.oas.models.media.MapSchema;
-import io.swagger.v3.oas.models.media.NumberSchema;
-import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.media.UUIDSchema;
 
 /**
@@ -127,7 +118,7 @@ public final class TypeConverter {
 
         if (context.isRequired()) {
             logger.debug(" overriding ptr validation to force required");
-            var withRequire = Validations.required(ptr.validation());
+            var withRequire = Validations.makeRequired(ptr.validation());
             return ImmutableParserTypeRef.builder().from(ptr)
                     .validation(withRequire)
                     .build();
@@ -140,6 +131,7 @@ public final class TypeConverter {
      * Contains reference information when converting a schema to a type reference.
      *
      * @param schema        the openapi schema
+     * @param schemaParser  the schema parser
      * @param propertyName  the reference property
      * @param parentDtoName the optional name of the parent dto
      * @param context       the content context of the reference
@@ -148,6 +140,7 @@ public final class TypeConverter {
      */
     record RefInfo(
             Schema<?> schema,
+            SchemaParser schemaParser,
             @Nullable String propertyName,
             @Nullable String parentDtoName,
             @Nullable ContentContext context,
@@ -166,7 +159,7 @@ public final class TypeConverter {
      *
      * This serves as a lazy reference to something that will eventually be resolved to a type in the model.
      *
-     * @param schema        the OpenApi schema to convert
+     * @param schema        the schema
      * @param propertyName  the name of the property the type is associated with, or null
      * @param parentDtoName the name of the DTO this schema is part of, or null
      * @return the found/created parser type reference
@@ -189,31 +182,33 @@ public final class TypeConverter {
      */
     public ParserTypeRef reference(Schema<?> schema, @Nullable String propertyName, @Nullable String parentDtoName, boolean isFormRef,
             @Nullable ContentContext context) {
-        String schemaType = schema.getType();
-        String schemaFormat = schema.getFormat();
-        String schemaRef = schema.get$ref();
+
+        SchemaParser sp = SchemaParser.of(schema);
+
+        String schemaType = sp.type();
+        String schemaFormat = sp.format();
 
         logger.debug("type/format: {}:{} {}/{} {}", parentDtoName, propertyName, schemaType, schemaFormat, schema.getClass());
-        logger.debug("ref {}", schemaRef);
 
         Validation validation = Validations.extractValidation(schema, false);
         logger.debug("validation {}", validation);
 
-        RefInfo ri = new RefInfo(schema, propertyName, parentDtoName, context, validation, isFormRef);
+        RefInfo ri = new RefInfo(schema, sp, propertyName, parentDtoName, context, validation, isFormRef);
 
-        return Stream.<TypeMapper>of(
+        ParserTypeRef refType = Stream.<TypeMapper>of(
                 this::createPrimitiveTypeRef,
                 this::createDtoRef,
+                this::createAnyofRef,
                 this::createArrayRef,
                 this::createByteArrayRef,
                 this::createMapRef,
-                this::createAnyofRef,
                 this::createComposedValidation, // before allofRef, should be combined
                 this::createAllofRef,
                 this::createOneofRef,
                 this::createNumberRef,
                 this::createDateTimeRef,
                 this::createDateRef,
+                this::createTimeRef,
                 this::createUUIDRef,
                 this::createStringRef,
                 this::createSupplementalValidation,
@@ -222,6 +217,8 @@ public final class TypeConverter {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No type found for " + schema));
+        logger.info(" to XXX: {}", refType);
+        return refType;
     }
 
     /**
@@ -231,44 +228,55 @@ public final class TypeConverter {
      * @return the found reference or null
      */
     @Nullable private ParserTypeRef createPrimitiveTypeRef(RefInfo ri) {
-        // If the property declares a primitive type *and* allOf is defined
-        // (as happens from Quarkus 3) ignore the found primitive. It is not
-        // the full story.
-        if (ri.schema.getAllOf() != null) {
+        SchemaParser schemaParser = ri.schemaParser;
+
+        // V31 spec combines stuff on [string] which would match
+        // String in the below. So bail out.
+        if (schemaParser.isRef()) {
             return null;
         }
 
-        Type type = findPrimitive(ri.schema);
+        // If the property declares a primitive type *and* allOf is defined
+        // (as happens from Quarkus 3) ignore the found primitive. It is not
+        // the full story.
+        if (schemaParser.isAllOf()) {
+            return null;
+        }
+
+        Type type = findPrimitive(schemaParser);
         if (type == null) {
             return null;
         }
 
-        List<?> enumeration = ri.schema.getEnum();
-        if (enumeration == null || ri.propertyName == null) {
+        // As of OpenApi specification V3.1 the type encodes nullable - move it to the validation
+        Validation validation = ri.validation();
+        if (schemaParser.isNullable()) {
+            validation = Validations.makeNullable(validation);
+        }
+
+        if (!schemaParser.isEnumeration() || ri.propertyName == null) {
             String name = type.typeName().name();
             logger.trace(" - createPrimitiveTypeRef {}", name);
-            return parserRefs.of(type, ri.validation);
+            return parserRefs.of(type, validation);
         }
+        List<String> enumValues = schemaParser.enumerationValues();
 
         String enumTypeName = naming.convertPropertyEnumTypeName(ri.propertyName);
         TypeName typeName = typeNames.of(enumTypeName);
 
-        List<String> enumValues = enumeration.stream()
-                .map(Objects::toString)
-                .toList();
         String name = typeName.name();
         logger.trace(" - createPrimitiveTypeRef enum {} {} {}", name, type, enumValues);
-        return parserRefs.of(TypeEnum.of(typeName, type, enumValues), ri.validation);
+        return parserRefs.of(TypeEnum.of(typeName, type, enumValues), validation);
     }
 
     /**
      * Finds a primitive type matching the given OpenApi schema.
      *
-     * @param schema the schema to look for type/format for
+     * @param sp the schema parser
      * @return the matching primitive, or null if no matches found
      */
-    private static @Nullable Primitive findPrimitive(Schema<?> schema) {
-        String typeFormat = schema.getType() + ":" + Objects.toString(schema.getFormat(), "");
+    private @Nullable Primitive findPrimitive(SchemaParser sp) {
+        String typeFormat = sp.type() + ":" + Objects.toString(sp.format(), "");
         for (var p : Primitive.values()) {
             if (p.openapiTypeFormat().equals(typeFormat)) {
                 return p;
@@ -278,12 +286,12 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createArrayRef(RefInfo ri) {
-        if (ri.schema instanceof ArraySchema a) {
-            ParserTypeRef innerType = reference(a.getItems(), ri.propertyName, ri.parentDtoName);
+        SchemaParser sp = ri.schemaParser;
+        if (sp.isArray()) {
+            ParserTypeRef innerType = reference(sp.itemsSchema(), ri.propertyName, ri.parentDtoName);
             logger.trace(" - createArrayRef {}", innerType);
 
-            Boolean isUnique = a.getUniqueItems();
-            if (isUnique != null && isUnique.booleanValue()) {
+            if (sp.isUnique()) {
                 return parserRefs.of(TypeSet.of(typeNames, innerType), ri.validation);
             }
 
@@ -297,7 +305,7 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createByteArrayRef(RefInfo ri) {
-        if (ri.schema instanceof BinarySchema || ri.schema instanceof FileSchema) {
+        if (ri.schemaParser().isBinary()) {
             logger.trace(" - createByteArrayRef");
             boolean isStream = ri.isFormRef || ri.propertyName == null;
             TypeByteArray impl = isStream ? TypeByteArray.getStream() : TypeByteArray.getArray();
@@ -307,18 +315,17 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createMapRef(RefInfo ri) {
-        if (ri.schema instanceof MapSchema m) {
-            Object additionalProperties = m.getAdditionalProperties();
-            if (additionalProperties instanceof Schema<?> innerSchema) {
-                logger.trace(" - createMapRef");
-                Type innerType = toReference(innerSchema);
-                return parserRefs.of(TypeMap.of(typeNames, innerType), ri.validation);
-            }
+        SchemaParser sp = ri.schemaParser();
+        if (sp.isMap()) {
+            Type innerType = reference(sp.mapInnerSchema(), ri.propertyName, ri.parentDtoName);
+            logger.trace(" - createMapRef inner type: {}", innerType.typeName().name());
+            return parserRefs.of(TypeMap.of(typeNames, innerType), ri.validation);
         }
         return null;
     }
 
     @Nullable private ParserTypeRef createComposedValidation(RefInfo ri) {
+        // FIXME:schema-parser
         if (ri.schema instanceof ComposedSchema cs
                 && findTypeValidation(cs) instanceof ParserTypeRef ptr) {
             logger.trace(" - createComposedValidation");
@@ -328,43 +335,44 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createAnyofRef(RefInfo ri) {
-        if (ri.schema instanceof ComposedSchema cs) {
+        SchemaParser sp = ri.schemaParser();
+        if (sp.isAnyOf()) {
+            logger.info("TRIGGER");
+
             // anyOf is classes implementing an interface
-            @SuppressWarnings("rawtypes")
-            List<Schema> anyOf = cs.getAnyOf();
-            if (anyOf != null && !anyOf.isEmpty()) {
-                List<ParserTypeRef> anyOfRefs = anyOf.stream()
-                        .map(this::toReference)
-                        .toList();
-                List<String> anyOfNames = anyOfRefs.stream()
-                        .map(ParserTypeRef::typeName)
-                        .map(TypeName::name)
-                        .sorted()
-                        .toList();
+            List<ParserTypeRef> anyOfRefs = sp.anyOfSchemas().stream()
+                    .map(this::toReference)
+                    .toList();
+            List<String> anyOfNames = anyOfRefs.stream()
+                    .map(ParserTypeRef::typeName)
+                    .map(TypeName::name)
+                    .sorted()
+                    .toList();
 
-                String interfaceName = cs.getName();
-                if (interfaceName == null) {
-                    interfaceName = String.join("", anyOfNames);
-                }
-
-                TypeName tn = typeNames.of(interfaceName);
-
-                logger.trace(" - createAnyofRef interface {} : {}", tn, anyOfRefs);
-
-                TypeInterface ti = parserTypes.getOrMakeInterface(tn, anyOfRefs);
-                return parserRefs.of(ti, ri.validation);
+            String interfaceName = sp.name();
+            if (interfaceName == null) {
+                interfaceName = String.join("", anyOfNames);
             }
+
+            TypeName tn = typeNames.of(interfaceName);
+
+            logger.trace(" - createAnyofRef interface {} : {}", tn, anyOfRefs);
+
+            TypeInterface ti = parserTypes.getOrMakeInterface(tn, anyOfRefs);
+            return parserRefs.of(ti, ri.validation);
         }
         return null;
     }
 
     @Nullable private ParserTypeRef createAllofRef(RefInfo ri) {
-        if (ri.schema instanceof ComposedSchema cs) {
+        SchemaParser sp = ri.schemaParser();
+        Schema<?> schema = sp.schema();
+        // FIXME:schema-parser
+        if (schema instanceof ComposedSchema cs) {
             @SuppressWarnings("rawtypes")
             List<Schema> allOf = cs.getAllOf();
 
             if (allOf != null && !allOf.isEmpty()) {
-
                 logger.trace("PROCESSING allOf:");
 
                 String dtoName = ri.parentDtoName();
@@ -398,9 +406,14 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createOneofRef(RefInfo ri) {
-        if (ri.schema instanceof ComposedSchema cs) {
+        SchemaParser sp = ri.schemaParser();
+
+        Schema<?> schema = sp.schema();
+
+        if (sp.isOneOf()) {
+
             @SuppressWarnings("rawtypes")
-            List<Schema> oneOf = cs.getOneOf();
+            List<Schema> oneOf = sp.oneOfSchemas();
             if (oneOf != null && !oneOf.isEmpty()) {
                 List<ParserTypeRef> oneOfRefs = oneOf.stream()
                         .map(Schema::get$ref)
@@ -408,7 +421,7 @@ public final class TypeConverter {
                         .filter(Objects::nonNull)
                         .toList();
 
-                if (cs.getDiscriminator() == null && !oneOfRefs.isEmpty()) {
+                if (schema.getDiscriminator() == null && !oneOfRefs.isEmpty()) {
                     // Handle oneof without descriminator
                     return createCombinedDto(ri, oneOfRefs);
                 } else {
@@ -448,7 +461,7 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createNumberRef(RefInfo ri) {
-        if (ri.schema instanceof NumberSchema) {
+        if (ri.schemaParser().isNumber()) {
             logger.trace(" - createNumberRef");
             return parserRefs.of(noFormatNumberType, ri.validation);
         }
@@ -456,7 +469,7 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createDateTimeRef(RefInfo ri) {
-        if (isDateTimeType(ri.schema)) {
+        if (ri.schemaParser().isDateTime(parserOpts.isFixupNullTypeDates())) {
             logger.trace(" - createDateTimeRef");
             return parserRefs.of(dateTimeType, ri.validation);
         }
@@ -464,9 +477,17 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createDateRef(RefInfo ri) {
-        if (isDateType(ri.schema)) {
+        if (ri.schemaParser().isDate(parserOpts.isFixupNullTypeDates())) {
             logger.trace(" - createDateRef");
             return parserRefs.of(TypeDate.get(), ri.validation);
+        }
+        return null;
+    }
+
+    @Nullable private ParserTypeRef createTimeRef(RefInfo ri) {
+        if (ri.schemaParser().isTime()) {
+            logger.trace(" - createTimeRef");
+            return parserRefs.of(TypeLocalTime.get(), ri.validation);
         }
         return null;
     }
@@ -480,12 +501,8 @@ public final class TypeConverter {
     }
 
     @Nullable private ParserTypeRef createStringRef(RefInfo ri) {
-        if (ri.schema instanceof StringSchema) {
+        if (ri.schemaParser().isString()) {
             logger.trace(" - createStringRef");
-            if (TypeLocalTime.OPENAPI_CUSTOM_FORMAT.equals(ri.schema.getFormat())) {
-                return parserRefs.of(TypeLocalTime.get(), ri.validation);
-            }
-
             return parserRefs.of(Primitive.STRING, ri.validation);
         }
         return null;
@@ -495,7 +512,7 @@ public final class TypeConverter {
         Schema<?> schema = ri.schema;
         // If no type and reference, assume it is supplemental validation
         // information for the other type in a ComposedSchema.
-        if (schema.getType() == null && schema.get$ref() == null
+        if (ri.schemaParser.type() == null
                 && (schema.getProperties() == null || schema.getProperties().isEmpty())) {
             logger.trace(" - createSupplementalValidation");
             return parserRefs.of(TypeValidation.of(ri.validation), ri.validation);
@@ -506,7 +523,8 @@ public final class TypeConverter {
     @Nullable private ParserTypeRef createObjectRef(RefInfo ri) {
         Schema<?> schema = ri.schema;
 
-        if (schema instanceof ObjectSchema || schema.getType() == null) {
+        SchemaParser sp = ri.schemaParser();
+        if (sp.isObject() || sp.type() == null) {
             boolean isPlainObject = schema.getProperties() == null || schema.getProperties().isEmpty();
             if (ri.propertyName == null) {
                 if (isPlainObject) {
@@ -559,22 +577,6 @@ public final class TypeConverter {
         logger.trace("Inline response object for path {}: {}", resourcePath, syntheticDtoName);
         Dto dto = createDto(syntheticDtoName, schema);
         return parserRefs.of(dto, ri.validation);
-    }
-
-    private boolean isDateType(Schema<?> schema) {
-        return schema instanceof DateSchema
-                || isBrokenDateTimeType(schema, "date");
-    }
-
-    private boolean isDateTimeType(Schema<?> schema) {
-        return schema instanceof DateTimeSchema
-                || isBrokenDateTimeType(schema, "date-time");
-    }
-
-    private boolean isBrokenDateTimeType(Schema<?> schema, String format) {
-        return parserOpts.isFixupNullTypeDates()
-                && schema.getType() == null
-                && format.equals(schema.getFormat());
     }
 
     /**

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
@@ -130,7 +130,7 @@ public final class TypeConverter {
     /**
      * Contains reference information when converting a schema to a type reference.
      *
-     * @param schema        the openapi schema
+     * @param schema        the OpenApi schema to convert
      * @param schemaParser  the schema parser
      * @param propertyName  the reference property
      * @param parentDtoName the optional name of the parent dto
@@ -217,7 +217,7 @@ public final class TypeConverter {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("No type found for " + schema));
-        logger.info(" to XXX: {}", refType);
+        logger.debug(" converted to: {}", refType);
         return refType;
     }
 

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Validations.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/Validations.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.models.media.Schema;
 /**
  * Validation factory.
  */
-public class Validations {
+public final class Validations {
+    /** The empty validation instance. */
     private static final Validation EMPTY_VALIDATION = Validation.empty();
+    /** The required validation instance. */
     private static final Validation REQUIRED_VALIDATION = Validation.validationRequired();
 
     /** Validation instances to make sure we only get one of each. */
@@ -51,11 +53,11 @@ public class Validations {
     }
 
     /**
-     * {@return a more relax validation; not required and nullable}
+     * {@return a more relaxed validation; not required and nullable}
      *
      * @param v the validation to relax
      */
-    public static Validation relax(Validation v) {
+    public static Validation makeRelaxed(Validation v) {
         Validation candidate = new Validation(false, true, v.readonly(),
                 v._minItems(), v._maxItems(), v._minLength(), v._maxLength(), v._minimum(), v._maximum(), v._pattern());
         return getInstance(candidate);
@@ -66,8 +68,19 @@ public class Validations {
      *
      * @param v the validation to enable require on
      */
-    public static Validation required(Validation v) {
+    public static Validation makeRequired(Validation v) {
         Validation candidate = new Validation(true, v.nullable(), v.readonly(),
+                v._minItems(), v._maxItems(), v._minLength(), v._maxLength(), v._minimum(), v._maximum(), v._pattern());
+        return getInstance(candidate);
+    }
+
+    /**
+     * {@return a validation that allows the type to be null}
+     *
+     * @param v the validation to enable require on
+     */
+    public static Validation makeNullable(Validation v) {
+        Validation candidate = new Validation(v.required(), true, v.readonly(),
                 v._minItems(), v._maxItems(), v._minLength(), v._maxLength(), v._minimum(), v._maximum(), v._pattern());
         return getInstance(candidate);
     }


### PR DESCRIPTION
This is still incomplete, but can handle (most of) the API elements in https://github.com/jskov/openapi-examples when rendered for version 3.1