### PR TITLE
Remove some of the simpler uses of Immutable

### DIFF
--- a/modules/generator-api/build.gradle
+++ b/modules/generator-api/build.gradle
@@ -1,9 +1,6 @@
 apply from: "${project.rootDir}/gradle/dk.mada.java.gradle"
 
 dependencies {
-    annotationProcessor (libs.immutablesApt)
-    compileOnly         (libs.immutablesAnn)
-
     testImplementation  (libs.bundles.testUnit)
 }
 

--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
@@ -493,14 +493,13 @@ public class ApiGenerator {
 
         String description = r.description().orElse("");
 
-        return CtxApiResponse.builder()
-                .baseType(baseType)
-                .code(r.code().asOpenApiStatus())
-                .containerType(containerType)
-                .description(StringRenderer.encodeForString(description))
-                .isUnique(isUnique)
-                .mediaType(mediaType)
-                .build();
+        return new CtxApiResponse(
+                r.code().asOpenApiStatus(),
+                StringRenderer.encodeForString(description),
+                baseType,
+                containerType,
+                mediaType,
+                isUnique);
     }
 
     // TODO: these should be combined smarter - base should take Content as argument instead, avoid use of streams

--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
@@ -139,11 +139,7 @@ public class ApiGenerator {
             imports.add(MicroProfile.REGISTER_PROVIDER);
         }
 
-        CtxApiExt apiExt = CtxApiExt.builder()
-                .mpRestClientConfigKey(clientKey)
-                .mpProviders(mpProviders)
-                .isJspecify(opts.isJspecify())
-                .build();
+        CtxApiExt apiExt = new CtxApiExt(clientKey, mpProviders, opts.isJspecify());
 
         Info info = model.info();
         return CtxApi.builder()

--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/tmpl/CtxApiExt.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/tmpl/CtxApiExt.java
@@ -2,24 +2,12 @@ package dk.mada.jaxrs.generator.mpclient.api.tmpl;
 
 import java.util.List;
 import java.util.Optional;
-import org.immutables.value.Value.Immutable;
 
 /**
  * Extended template data for a resource class.
+ *
+ * @param mpRestClientConfigKey the optional micro profile rest client config key
+ * @param mpProviders the fully qualified class names of MP providers
+ * @param isJspecify true if jspecify Nullable annotations should be used
  */
-@Immutable
-public interface CtxApiExt {
-    /** {@return a builder for this type} */
-    static ImmutableCtxApiExt.Builder builder() {
-        return ImmutableCtxApiExt.builder();
-    }
-
-    /** {@return the optional micro profile rest client config key} */
-    Optional<String> mpRestClientConfigKey();
-
-    /** {@return fully qualified class names of MP providers} */
-    List<String> mpProviders();
-
-    /** {@return true if jspecify Nullable annotations should be used} */
-    boolean isJspecify();
-}
+public record CtxApiExt(Optional<String> mpRestClientConfigKey, List<String> mpProviders, boolean isJspecify) {}

--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/tmpl/CtxApiResponse.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/tmpl/CtxApiResponse.java
@@ -1,34 +1,23 @@
 package dk.mada.jaxrs.generator.mpclient.api.tmpl;
 
 import java.util.Optional;
-import org.immutables.value.Value.Immutable;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Template data for an API operation response.
+ *
+ * @param code          the HTTP response of this response (or 'default')
+ * @param description   the description of this response
+ * @param baseType      the type of this response, or null
+ * @param containerType the container type of this response, or null
+ * @param mediaType     the media-type of this response if necessary
+ * @param isUnique      true if the container is a set (array with unique
+ *                      elements)
  */
-@Immutable
-public interface CtxApiResponse {
-    /** {@return a builder for this type} */
-    static ImmutableCtxApiResponse.Builder builder() {
-        return ImmutableCtxApiResponse.builder();
-    }
-
-    /** {@return the HTTP response of this response (or 'default')} */
-    String code();
-
-    /** {@return the optional description of this response} */
-    Optional<String> description();
-
-    /** {@return the type of this response, or null} */
-    @Nullable String baseType();
-
-    /** {@return the container type of this response, or null} */
-    @Nullable String containerType();
-
-    /** {@return the media-type of this response if necessary} */
-    Optional<String> mediaType();
-
-    /** {@return true if the container is a set (array with unique elements)} */
-    boolean isUnique();
-}
+public record CtxApiResponse(
+        String code,
+        String description,
+        @Nullable String baseType,
+        @Nullable String containerType,
+        Optional<String> mediaType,
+        boolean isUnique) {}

--- a/modules/parser/build.gradle
+++ b/modules/parser/build.gradle
@@ -10,9 +10,6 @@ dependencies {
     implementation      (libs.logger)
     implementation      (libs.swaggerParser)
 
-    annotationProcessor (libs.immutablesApt)
-    compileOnly         (libs.immutablesAnn)
-
     compileOnly         (libs.jspecify)
 }
 

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/ParserTypeRef.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/ParserTypeRef.java
@@ -4,18 +4,28 @@ import dk.mada.jaxrs.model.Validation;
 import dk.mada.jaxrs.model.types.Reference;
 import dk.mada.jaxrs.model.types.Type;
 import dk.mada.jaxrs.model.types.TypeName;
-import org.immutables.value.Value.Immutable;
 
 /**
  * A reference to types used during parsing.
  *
- * This is necessary, because the model may not yet have been populated with DTOs that are defined further down in the
- * schema.
+ * This is necessary, because the model may not yet have been populated with
+ * DTOs that are defined further down in the schema.
  *
- * When the entire scheme is parsed, these will be dereferenced to proper model TypeRefs.
+ * When the entire scheme is parsed, these will be dereferenced to proper model
+ * TypeRefs.
+ *
+ * @param refType     the referenced type - note that this may be unknown
+ * @param refTypeName the referenced type name
+ * @param validation  the validation
+ *
  */
-@Immutable
-public interface ParserTypeRef extends Reference {
+public record ParserTypeRef(Type refType, TypeName refTypeName, Validation validation) implements Reference {
+
+    @Override
+    public TypeName typeName() {
+        return refTypeName();
+    }
+
     /**
      * Creates a new reference to a type (a primitive or special type)
      *
@@ -25,11 +35,7 @@ public interface ParserTypeRef extends Reference {
      * @return a reference to the type
      */
     static ParserTypeRef of(Type refType, TypeName refTypeName, Validation validation) {
-        return ImmutableParserTypeRef.builder()
-                .refType(refType)
-                .refTypeName(refTypeName)
-                .validation(validation)
-                .build();
+        return new ParserTypeRef(refType, refTypeName, validation);
     }
 
     /**
@@ -41,17 +47,5 @@ public interface ParserTypeRef extends Reference {
      */
     static ParserTypeRef of(TypeName refTypeName, Validation validation) {
         return of(TypeUnknownAtParseTime.get(), refTypeName, validation);
-    }
-
-    /** {@return the referenced type name} */
-    TypeName refTypeName();
-
-    /** {@return the referenced type - note that this may be unknown} */
-    @Override
-    Type refType();
-
-    @Override
-    default TypeName typeName() {
-        return refTypeName();
     }
 }

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
@@ -122,10 +122,7 @@ public final class TypeConverter {
         if (context.isRequired()) {
             logger.debug(" overriding ptr validation to force required");
             var withRequire = Validations.makeRequired(ptr.validation());
-            return ImmutableParserTypeRef.builder()
-                    .from(ptr)
-                    .validation(withRequire)
-                    .build();
+            return new ParserTypeRef(ptr.refType(), ptr.refTypeName(), withRequire);
         } else {
             return ptr;
         }


### PR DESCRIPTION
Want to switch to records.
Most of the other instances need to converted to composites as they are too big to sensibly have as one big record.