### PR TITLE
Properly handle naming of interfaces

### DIFF
--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/dto/DtoGenerator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/dto/DtoGenerator.java
@@ -131,16 +131,19 @@ public class DtoGenerator {
     }
 
     private CtxInterface makeCtxInterface(TypeInterface ti) {
-        var imports = Imports.newInterface(opts);
+        Naming naming = model.naming();
 
+        var imports = Imports.newInterface(opts);
         String implementations = ti.implementations().stream()
-                .map(tn -> tn.name() + ".class")
+                .map(tn -> naming.convertTypeName(tn.name()) + ".class")
                 .sorted()
                 .collect(joining(", "));
 
+        String interfaceClassname = naming.convertTypeName(ti.typeName().name());
+
         Info info = model.info();
         return CtxInterface.builder()
-                .classname(ti.typeName().name())
+                .classname(interfaceClassname)
                 .appDescription(info.description())
                 .appName(info.title())
                 .version(info.version())

--- a/modules/generator/src/test/java/mada/fixture/TestIterator.java
+++ b/modules/generator/src/test/java/mada/fixture/TestIterator.java
@@ -52,7 +52,7 @@ class TestIterator {
         // Handy when working on a single test
 //        String testNameContains = "opts/generator/validation/body";
 //        String testNameContains = "unknown_enum";
-        String testNameContains = "petstore";
+        String testNameContains = "api/interfaces";
 //        String testNameContains = "e2e/specs/v3_0";
 //        String testNameContains = "e2e/specs/v3_1/all";
 //        String testNameContains = "e2e/specs/v3_1/anyof";

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/api/Api_InterfacesApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/api/Api_InterfacesApi.java
@@ -10,7 +10,7 @@ package mada.tests.e2e.api.interfaces.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import mada.tests.e2e.api.interfaces.dto.ImplAImplB;
+import mada.tests.e2e.api.interfaces.dto.BadNameImplB_BadName_ImplA_ImplA_ImplB;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
@@ -20,22 +20,22 @@ public interface Api_InterfacesApi {
   /**
    * apiInterfacesInterfaceGet.
    *
-   * @return ImplAImplB
+   * @return BadNameImplB_BadName_ImplA_ImplA_ImplB
    */
   @GET
   @Path("/interface")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
-  ImplAImplB apiInterfacesInterfaceGet();
+  @APIResponseSchema(BadNameImplB_BadName_ImplA_ImplA_ImplB.class)
+  BadNameImplB_BadName_ImplA_ImplA_ImplB apiInterfacesInterfaceGet();
 
   /**
    * apiInterfacesListGet.
    *
-   * @return ImplAImplB
+   * @return BadNameImplB_BadName_ImplA_ImplA_ImplB
    */
   @GET
   @Path("/list")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
-  ImplAImplB apiInterfacesListGet();
+  @APIResponseSchema(BadNameImplB_BadName_ImplA_ImplA_ImplB.class)
+  BadNameImplB_BadName_ImplA_ImplA_ImplB apiInterfacesListGet();
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadNameImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadNameImplB.java
@@ -6,21 +6,21 @@
  * Contact: email@example.com
  */
 
-package mada.tests.e2e.specs.v3_0.dto;
+package mada.tests.e2e.api.interfaces.dto;
 
 import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**
- * SubA
+ * BadNameImplB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubA extends Super implements SubA_SubB {
+public class BadNameImplB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;
 
-  public SubA bar(Integer bar) {
+  public BadNameImplB bar(Integer bar) {
     this.bar = bar;
     return this;
   }
@@ -42,24 +42,22 @@ public class SubA extends Super implements SubA_SubB {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SubA)) {
+    if (!(o instanceof BadNameImplB)) {
       return false;
     }
-    SubA other = (SubA) o;
-    return Objects.equals(this.bar, other.bar) &&
-        super.equals(o);
+    BadNameImplB other = (BadNameImplB) o;
+    return Objects.equals(this.bar, other.bar);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bar, super.hashCode());
+    return Objects.hash(bar);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SubA {");
-    sb.append("\n    ").append(toIndentedString(super.toString()));
+    sb.append("class BadNameImplB {");
     sb.append("\n    bar: ").append(toIndentedString(bar));
     sb.append("\n}");
     return sb.toString();

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadNameImplB_BadName_ImplA_ImplA_ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadNameImplB_BadName_ImplA_ImplA_ImplB.java
@@ -6,10 +6,10 @@
  * Contact: email@example.com
  */
 
-package mada.tests.e2e.specs.v3_1.all.dto;
+package mada.tests.e2e.api.interfaces.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(anyOf = { SubA.class, SubB.class })
-public interface SubASubB {
+@Schema(anyOf = { BadNameImplB.class, BadName_ImplA.class, ImplA.class, ImplB.class })
+public interface BadNameImplB_BadName_ImplA_ImplA_ImplB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadName_ImplA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/BadName_ImplA.java
@@ -6,35 +6,35 @@
  * Contact: email@example.com
  */
 
-package mada.tests.e2e.specs.v3_0.dto;
+package mada.tests.e2e.api.interfaces.dto;
 
 import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
 
 /**
- * SubA
+ * BadName_ImplA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubA extends Super implements SubA_SubB {
-  public static final String JSON_PROPERTY_BAR = "bar";
-  @JsonbProperty(JSON_PROPERTY_BAR)
-  private Integer bar;
+public class BadName_ImplA {
+  public static final String JSON_PROPERTY_FOO = "foo";
+  @JsonbProperty(JSON_PROPERTY_FOO)
+  private Integer foo;
 
-  public SubA bar(Integer bar) {
-    this.bar = bar;
+  public BadName_ImplA foo(Integer foo) {
+    this.foo = foo;
     return this;
   }
 
   /**
-   * Get bar
-   * @return bar
+   * Get foo
+   * @return foo
    **/
-  public Integer getBar() {
-    return bar;
+  public Integer getFoo() {
+    return foo;
   }
 
-  public void setBar(Integer bar) {
-    this.bar = bar;
+  public void setFoo(Integer foo) {
+    this.foo = foo;
   }
 
   @Override
@@ -42,25 +42,23 @@ public class SubA extends Super implements SubA_SubB {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SubA)) {
+    if (!(o instanceof BadName_ImplA)) {
       return false;
     }
-    SubA other = (SubA) o;
-    return Objects.equals(this.bar, other.bar) &&
-        super.equals(o);
+    BadName_ImplA other = (BadName_ImplA) o;
+    return Objects.equals(this.foo, other.foo);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(bar, super.hashCode());
+    return Objects.hash(foo);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class SubA {");
-    sb.append("\n    ").append(toIndentedString(super.toString()));
-    sb.append("\n    bar: ").append(toIndentedString(bar));
+    sb.append("class BadName_ImplA {");
+    sb.append("\n    foo: ").append(toIndentedString(foo));
     sb.append("\n}");
     return sb.toString();
   }

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/ImplA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/ImplA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplA implements ImplAImplB {
+public class ImplA implements BadNameImplB_BadName_ImplA_ImplA_ImplB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/dto/ImplB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplB implements ImplAImplB {
+public class ImplB implements BadNameImplB_BadName_ImplA_ImplA_ImplB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/openapi.yaml
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/interfaces/openapi.yaml
@@ -28,6 +28,8 @@ paths:
             application/json:
               schema:
                 anyOf:
+                - $ref: '#/components/schemas/BadName.ImplA'
+                - $ref: '#/components/schemas/BadName-ImplB'
                 - $ref: '#/components/schemas/ImplA'
                 - $ref: '#/components/schemas/ImplB'
   /api/interfaces/list:
@@ -42,10 +44,24 @@ paths:
               schema:
                 type: array
                 anyOf:
+                - $ref: '#/components/schemas/BadName.ImplA'
+                - $ref: '#/components/schemas/BadName-ImplB'
                 - $ref: '#/components/schemas/ImplA'
                 - $ref: '#/components/schemas/ImplB'
 components:
   schemas:
+    BadName.ImplA:
+      type: object
+      properties:
+        foo:
+          format: int32
+          type: integer
+    BadName-ImplB:
+      type: object
+      properties:
+        bar:
+          format: int32
+          type: integer
     ImplA:
       type: object
       properties:

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/api/Api_InterfacesApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/api/Api_InterfacesApi.java
@@ -12,7 +12,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 
-import mada.tests.e2e.dto.inheritance.jackson_fasterxml.dto.SubASubB;
+import mada.tests.e2e.dto.inheritance.jackson_fasterxml.dto.SubA_SubB;
 
 @javax.annotation.Generated(value = "dk.mada.jaxrs.Generator")
 @Path("/api/interfaces/super")
@@ -25,6 +25,6 @@ public interface Api_InterfacesApi {
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(SubASubB.class)
-  SubASubB apiInterfacesSuperGet();
+  @APIResponseSchema(SubA_SubB.class)
+  SubA_SubB apiInterfacesSuperGet();
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubA.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * SubA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubA extends Super implements SubASubB {
+public class SubA extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubA_SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubA_SubB.java
@@ -6,10 +6,10 @@
  * Contact: email@example.com
  */
 
-package mada.tests.e2e.api.interfaces.dto;
+package mada.tests.e2e.dto.inheritance.jackson_fasterxml.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(anyOf = { ImplA.class, ImplB.class })
-public interface ImplAImplB {
+@Schema(anyOf = { SubA.class, SubB.class })
+public interface SubA_SubB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/inheritance/jackson_fasterxml/dto/SubB.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * SubB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubB extends Super implements SubASubB {
+public class SubB extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * SubA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubA extends Super implements SubASubB {
+public class SubA extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubA_SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubA_SubB.java
@@ -8,5 +8,5 @@
 
 package mada.tests.e2e.opts.generator.openapi_schema.dto;
 
-public interface SubASubB {
+public interface SubA_SubB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/opts/generator/openapi_schema/dto/SubB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * SubB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubB extends Super implements SubASubB {
+public class SubB extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/api/Api_InterfacesApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/api/Api_InterfacesApi.java
@@ -10,8 +10,8 @@ package mada.tests.e2e.specs.v3_0.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import mada.tests.e2e.specs.v3_0.dto.ImplAImplB;
-import mada.tests.e2e.specs.v3_0.dto.SubASubB;
+import mada.tests.e2e.specs.v3_0.dto.ImplA_ImplB;
+import mada.tests.e2e.specs.v3_0.dto.SubA_SubB;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
@@ -21,33 +21,33 @@ public interface Api_InterfacesApi {
   /**
    * apiInterfacesInterfaceGet.
    *
-   * @return ImplAImplB
+   * @return ImplA_ImplB
    */
   @GET
   @Path("/interface")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
-  ImplAImplB apiInterfacesInterfaceGet();
+  @APIResponseSchema(ImplA_ImplB.class)
+  ImplA_ImplB apiInterfacesInterfaceGet();
 
   /**
    * apiInterfacesListGet.
    *
-   * @return ImplAImplB
+   * @return ImplA_ImplB
    */
   @GET
   @Path("/list")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
-  ImplAImplB apiInterfacesListGet();
+  @APIResponseSchema(ImplA_ImplB.class)
+  ImplA_ImplB apiInterfacesListGet();
 
   /**
    * apiInterfacesSuperGet.
    *
-   * @return SubASubB
+   * @return SubA_SubB
    */
   @GET
   @Path("/super")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(SubASubB.class)
-  SubASubB apiInterfacesSuperGet();
+  @APIResponseSchema(SubA_SubB.class)
+  SubA_SubB apiInterfacesSuperGet();
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplA implements ImplAImplB {
+public class ImplA implements ImplA_ImplB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplA_ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplA_ImplB.java
@@ -10,6 +10,6 @@ package mada.tests.e2e.specs.v3_0.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(anyOf = { SubA.class, SubB.class })
-public interface SubASubB {
+@Schema(anyOf = { ImplA.class, ImplB.class })
+public interface ImplA_ImplB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/ImplB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplB implements ImplAImplB {
+public class ImplB implements ImplA_ImplB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/SubA_SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/SubA_SubB.java
@@ -10,6 +10,6 @@ package mada.tests.e2e.specs.v3_0.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
-@Schema(anyOf = { ImplA.class, ImplB.class })
-public interface ImplAImplB {
+@Schema(anyOf = { SubA.class, SubB.class })
+public interface SubA_SubB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_0/dto/SubB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * SubB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubB extends Super implements SubASubB {
+public class SubB extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/api/Api_InterfacesApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/api/Api_InterfacesApi.java
@@ -10,8 +10,8 @@ package mada.tests.e2e.specs.v3_1.all.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import mada.tests.e2e.specs.v3_1.all.dto.ImplAImplB;
-import mada.tests.e2e.specs.v3_1.all.dto.SubASubB;
+import mada.tests.e2e.specs.v3_1.all.dto.ImplA_ImplB;
+import mada.tests.e2e.specs.v3_1.all.dto.SubA_SubB;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 
@@ -22,36 +22,36 @@ public interface Api_InterfacesApi {
   /**
    * Get Interface.
    *
-   * @return ImplAImplB
+   * @return ImplA_ImplB
    */
   @GET
   @Path("/interface")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
+  @APIResponseSchema(ImplA_ImplB.class)
   @Operation(summary = "Get Interface")
-  ImplAImplB apiInterfacesInterfaceGet();
+  ImplA_ImplB apiInterfacesInterfaceGet();
 
   /**
    * Get Interface List.
    *
-   * @return ImplAImplB
+   * @return ImplA_ImplB
    */
   @GET
   @Path("/list")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
+  @APIResponseSchema(ImplA_ImplB.class)
   @Operation(summary = "Get Interface List")
-  ImplAImplB apiInterfacesListGet();
+  ImplA_ImplB apiInterfacesListGet();
 
   /**
    * Get Super.
    *
-   * @return SubASubB
+   * @return SubA_SubB
    */
   @GET
   @Path("/super")
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(SubASubB.class)
+  @APIResponseSchema(SubA_SubB.class)
   @Operation(summary = "Get Super")
-  SubASubB apiInterfacesSuperGet();
+  SubA_SubB apiInterfacesSuperGet();
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplA implements ImplAImplB {
+public class ImplA implements ImplA_ImplB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplA_ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplA_ImplB.java
@@ -11,5 +11,5 @@ package mada.tests.e2e.specs.v3_1.all.dto;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(anyOf = { ImplA.class, ImplB.class })
-public interface ImplAImplB {
+public interface ImplA_ImplB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/ImplB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplB implements ImplAImplB {
+public class ImplB implements ImplA_ImplB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * SubA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubA extends Super implements SubASubB {
+public class SubA extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubA_SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubA_SubB.java
@@ -6,10 +6,10 @@
  * Contact: email@example.com
  */
 
-package mada.tests.e2e.dto.inheritance.jackson_fasterxml.dto;
+package mada.tests.e2e.specs.v3_1.all.dto;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(anyOf = { SubA.class, SubB.class })
-public interface SubASubB {
+public interface SubA_SubB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/all/dto/SubB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * SubB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class SubB extends Super implements SubASubB {
+public class SubB extends Super implements SubA_SubB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/api/Api_InterfacesApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/api/Api_InterfacesApi.java
@@ -10,7 +10,7 @@ package mada.tests.e2e.specs.v3_1.anyof.api;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import mada.tests.e2e.specs.v3_1.anyof.dto.ImplAImplB;
+import mada.tests.e2e.specs.v3_1.anyof.dto.ImplA_ImplB;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponseSchema;
 
@@ -21,11 +21,11 @@ public interface Api_InterfacesApi {
   /**
    * Get Interface List.
    *
-   * @return ImplAImplB
+   * @return ImplA_ImplB
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @APIResponseSchema(ImplAImplB.class)
+  @APIResponseSchema(ImplA_ImplB.class)
   @Operation(summary = "Get Interface List")
-  ImplAImplB apiInterfacesListGet();
+  ImplA_ImplB apiInterfacesListGet();
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplA.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplA.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplA
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplA implements ImplAImplB {
+public class ImplA implements ImplA_ImplB {
   public static final String JSON_PROPERTY_FOO = "foo";
   @JsonbProperty(JSON_PROPERTY_FOO)
   private Integer foo;

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplA_ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplA_ImplB.java
@@ -11,5 +11,5 @@ package mada.tests.e2e.specs.v3_1.anyof.dto;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
 @Schema(anyOf = { ImplA.class, ImplB.class })
-public interface ImplAImplB {
+public interface ImplA_ImplB {
 }

--- a/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/specs/v3_1/anyof/dto/ImplB.java
@@ -15,7 +15,7 @@ import javax.json.bind.annotation.JsonbProperty;
  * ImplB
  */
 @javax.annotation.processing.Generated(value = "dk.mada.jaxrs.Generator")
-public class ImplB implements ImplAImplB {
+public class ImplB implements ImplA_ImplB {
   public static final String JSON_PROPERTY_BAR = "bar";
   @JsonbProperty(JSON_PROPERTY_BAR)
   private Integer bar;

--- a/modules/generator/src/test/resources/logging-test.properties
+++ b/modules/generator/src/test/resources/logging-test.properties
@@ -31,4 +31,4 @@ dk.mada.jaxrs.openapi.DtoTransformer.level = INFO
 dk.mada.jaxrs.openapi.Parser.level = DEBUG
 dk.mada.jaxrs.openapi.ParserTypes.level = INFO
 dk.mada.jaxrs.openapi.Resolver.level = INFO
-dk.mada.jaxrs.openapi.TypeConverter.level = INFO
+dk.mada.jaxrs.openapi.TypeConverter.level = ALL

--- a/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
+++ b/modules/parser/src/main/java/dk/mada/jaxrs/openapi/TypeConverter.java
@@ -358,10 +358,10 @@ public final class TypeConverter {
 
             String interfaceName = sp.name();
             if (interfaceName == null) {
-                interfaceName = String.join("", anyOfNames);
+                interfaceName = String.join("_", anyOfNames);
             }
 
-            TypeName tn = typeNames.of(interfaceName);
+            TypeName tn = typeNames.of(naming.convertTypeName(interfaceName));
 
             logger.trace(" - createAnyofRef interface {} : {}", tn, anyOfRefs);
 


### PR DESCRIPTION
Fixes problem of bad Java type names from the OpenApi document. Also makes it easier see the type components in the synthetic interfaces.