### PR TITLE
Fix getter/setter naming for fields using dash/underscore

### DIFF
--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/dto/PropertyGenerator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/dto/PropertyGenerator.java
@@ -223,10 +223,11 @@ public class PropertyGenerator {
         // of a 'xX'-prefixed field to be named 'getxX'. Although
         // this is different from Bean Spec naming for getters/setters.
         //
-        // See https://github.com/FasterXML/jackson-databind/blob/2.15...
-        // /src/main/java/com/fasterxml/jackson/databind/introspect...
-        // /DefaultAccessorNamingStrategy.java#L182
-        if (name.length() > 1 && Character.isUpperCase(name.charAt(1))) {
+        // See <a
+        // href="https://github.com/FasterXML/jackson-databind/blob/2.15/src/main/java/com/fasterxml/jackson/databind/introspect/DefaultAccessorNamingStrategy.java#L182">this</a>.
+        //
+        // <a href="https://github.com/fasterxml/jackson-databind/issues/653">This</a> suggests an option may be needed.
+        if (camelized.length() > 1 && Character.isUpperCase(camelized.charAt(1))) {
             camelized = Character.toLowerCase(name.charAt(0)) + camelized.substring(1);
         }
 

--- a/modules/generator/src/test/java/mada/fixture/TestIterator.java
+++ b/modules/generator/src/test/java/mada/fixture/TestIterator.java
@@ -52,7 +52,7 @@ class TestIterator {
         // Handy when working on a single test
 //        String testNameContains = "opts/generator/validation/body";
 //        String testNameContains = "unknown_enum";
-        String testNameContains = "opts/generator/security";
+        String testNameContains = "bean_naming";
 //        String testNameContains = "e2e/specs/v3_0";
 //        String testNameContains = "e2e/specs/v3_1/all";
 //        String testNameContains = "e2e/specs/v3_1/anyof";

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/bean_naming/dto/BeanNaming.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/bean_naming/dto/BeanNaming.java
@@ -22,6 +22,10 @@ public class BeanNaming {
   @JsonbProperty(JSON_PROPERTY_A_CAMEL_INT)
   private Integer aCamelInt;
 
+  public static final String JSON_PROPERTY_A_DIFFERENT_CAMEL_BOOL = "a_different_camel_bool";
+  @JsonbProperty(JSON_PROPERTY_A_DIFFERENT_CAMEL_BOOL)
+  private Boolean aDifferentCamelBool;
+
   public static final String JSON_PROPERTY_ALLCAPSBOOL = "ALLCAPSBOOL";
   @JsonbProperty(JSON_PROPERTY_ALLCAPSBOOL)
   private Boolean aLLCAPSBOOL;
@@ -37,6 +41,10 @@ public class BeanNaming {
   public static final String JSON_PROPERTY_DOWN_INT = "downInt";
   @JsonbProperty(JSON_PROPERTY_DOWN_INT)
   private Integer downInt;
+
+  public static final String JSON_PROPERTY_I_NUMBER = "i-number";
+  @JsonbProperty(JSON_PROPERTY_I_NUMBER)
+  private Short iNumber;
 
   public static final String JSON_PROPERTY_UPPER_BOOL = "UpperBool";
   @JsonbProperty(JSON_PROPERTY_UPPER_BOOL)
@@ -86,6 +94,23 @@ public class BeanNaming {
 
   public void setaCamelInt(Integer aCamelInt) {
     this.aCamelInt = aCamelInt;
+  }
+
+  public BeanNaming aDifferentCamelBool(Boolean aDifferentCamelBool) {
+    this.aDifferentCamelBool = aDifferentCamelBool;
+    return this;
+  }
+
+  /**
+   * Get aDifferentCamelBool
+   * @return aDifferentCamelBool
+   **/
+  public Boolean isaDifferentCamelBool() {
+    return aDifferentCamelBool;
+  }
+
+  public void setaDifferentCamelBool(Boolean aDifferentCamelBool) {
+    this.aDifferentCamelBool = aDifferentCamelBool;
   }
 
   public BeanNaming aLLCAPSBOOL(Boolean aLLCAPSBOOL) {
@@ -154,6 +179,23 @@ public class BeanNaming {
 
   public void setDownInt(Integer downInt) {
     this.downInt = downInt;
+  }
+
+  public BeanNaming iNumber(Short iNumber) {
+    this.iNumber = iNumber;
+    return this;
+  }
+
+  /**
+   * Get iNumber
+   * @return iNumber
+   **/
+  public Short getiNumber() {
+    return iNumber;
+  }
+
+  public void setiNumber(Short iNumber) {
+    this.iNumber = iNumber;
   }
 
   public BeanNaming upperBool(Boolean upperBool) {
@@ -235,10 +277,12 @@ public class BeanNaming {
     BeanNaming other = (BeanNaming) o;
     return Objects.equals(this.aCamelBool, other.aCamelBool) &&
         Objects.equals(this.aCamelInt, other.aCamelInt) &&
+        Objects.equals(this.aDifferentCamelBool, other.aDifferentCamelBool) &&
         Objects.equals(this.aLLCAPSBOOL, other.aLLCAPSBOOL) &&
         Objects.equals(this.aLLCAPSINT, other.aLLCAPSINT) &&
         Objects.equals(this.downBool, other.downBool) &&
         Objects.equals(this.downInt, other.downInt) &&
+        Objects.equals(this.iNumber, other.iNumber) &&
         Objects.equals(this.upperBool, other.upperBool) &&
         Objects.equals(this.upperInt, other.upperInt) &&
         Objects.equals(this.withSlash, other.withSlash) &&
@@ -247,7 +291,7 @@ public class BeanNaming {
 
   @Override
   public int hashCode() {
-    return Objects.hash(aCamelBool, aCamelInt, aLLCAPSBOOL, aLLCAPSINT, downBool, downInt, upperBool, upperInt, withSlash, withUnderscore);
+    return Objects.hash(aCamelBool, aCamelInt, aDifferentCamelBool, aLLCAPSBOOL, aLLCAPSINT, downBool, downInt, iNumber, upperBool, upperInt, withSlash, withUnderscore);
   }
 
   @Override
@@ -256,10 +300,12 @@ public class BeanNaming {
     sb.append("class BeanNaming {");
     sb.append("\n    aCamelBool: ").append(toIndentedString(aCamelBool));
     sb.append("\n    aCamelInt: ").append(toIndentedString(aCamelInt));
+    sb.append("\n    aDifferentCamelBool: ").append(toIndentedString(aDifferentCamelBool));
     sb.append("\n    aLLCAPSBOOL: ").append(toIndentedString(aLLCAPSBOOL));
     sb.append("\n    aLLCAPSINT: ").append(toIndentedString(aLLCAPSINT));
     sb.append("\n    downBool: ").append(toIndentedString(downBool));
     sb.append("\n    downInt: ").append(toIndentedString(downInt));
+    sb.append("\n    iNumber: ").append(toIndentedString(iNumber));
     sb.append("\n    upperBool: ").append(toIndentedString(upperBool));
     sb.append("\n    upperInt: ").append(toIndentedString(upperInt));
     sb.append("\n    withSlash: ").append(toIndentedString(withSlash));

--- a/modules/generator/src/test/java/mada/tests/e2e/dto/bean_naming/openapi.yaml
+++ b/modules/generator/src/test/java/mada/tests/e2e/dto/bean_naming/openapi.yaml
@@ -43,3 +43,10 @@ components:
           type: boolean
         with_underscore:
           type: boolean
+        # Jackson and JsonBinding use special (broken?) conventions when translating xX field names
+        # But https://github.com/fasterxml/jackson-databind/issues/653
+        # implies this translation eventually needs an option here
+        a_different_camel_bool:
+          type: boolean
+        i-number:
+          type: integer

--- a/modules/generator/src/test/java/mada/tests/e2e/record/bean_naming/dto/BeanNaming.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/record/bean_naming/dto/BeanNaming.java
@@ -22,6 +22,10 @@ public record BeanNaming(
   @Nullable
   Integer aCamelInt,
 
+  @JsonbProperty("a_different_camel_bool")
+  @Nullable
+  Boolean aDifferentCamelBool,
+
   @JsonbProperty("ALLCAPSBOOL")
   @Nullable
   Boolean aLLCAPSBOOL,
@@ -37,6 +41,10 @@ public record BeanNaming(
   @JsonbProperty("downInt")
   @Nullable
   Integer downInt,
+
+  @JsonbProperty("i-number")
+  @Nullable
+  Short iNumber,
 
   @JsonbProperty("UpperBool")
   @Nullable

--- a/modules/generator/src/test/java/mada/tests/e2e/record/bean_naming/openapi.yaml
+++ b/modules/generator/src/test/java/mada/tests/e2e/record/bean_naming/openapi.yaml
@@ -43,3 +43,7 @@ components:
           type: boolean
         with_underscore:
           type: boolean
+        a_different_camel_bool:
+          type: boolean
+        i-number:
+          type: integer


### PR DESCRIPTION
Jackson/JsonBinding do not quite follow Bean naming. And the handling of this was off.

This fixes #838