### PR TITLE
Hardwired handling of parameter names conflicts

### DIFF
--- a/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
+++ b/modules/generator/src/main/java/dk/mada/jaxrs/generator/mpclient/api/ApiGenerator.java
@@ -41,6 +41,7 @@ import dk.mada.jaxrs.model.types.TypeSet;
 import dk.mada.jaxrs.model.types.TypeVoid;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -328,14 +329,20 @@ public class ApiGenerator {
         boolean addAuthHeader =
                 authHeaderPref == AuthHeader.ON || (authHeaderPref == AuthHeader.API && op.addAuthorizationHeader());
 
+        // For keeping track of parameter naming conflicts
+        Set<String> assignedNames = new HashSet<>();
+
         if (addAuthHeader) {
             Primitive type = Primitive.STRING;
             ValidationAndType validationAndType =
                     renderValidationAndType(imports, type, Validation.validationRequired());
 
+            String paramName = "auth";
+            assignedNames.add(paramName);
+
             params.add(CtxApiParam.builder()
                     .baseName("Authorization")
-                    .paramName("auth")
+                    .paramName(paramName)
                     .dataType(validationAndType.typeNameWithValidation())
                     .validation(validationAndType.valCtx())
                     .isContainer(false)
@@ -355,6 +362,10 @@ public class ApiGenerator {
 
             String name = p.name();
             String paramName = naming.convertParameterName(name);
+            if (assignedNames.contains(paramName)) {
+                paramName = paramName + p.nameConflictSuffixExt();
+            }
+            assignedNames.add(paramName);
 
             Type type = ref.refType();
 

--- a/modules/generator/src/test/java/mada/fixture/TestIterator.java
+++ b/modules/generator/src/test/java/mada/fixture/TestIterator.java
@@ -50,7 +50,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "record/empty";
+        String testNameContains = "api/params/header";
 //        String testNameContains = "params/body/";
 //        String testNameContains = "additional_properties";
 //        String testNameContains = "e2e/specs/v3_0";

--- a/modules/generator/src/test/java/mada/tests/e2e/api/params/header/api/Params_HeaderApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/params/header/api/Params_HeaderApi.java
@@ -45,14 +45,14 @@ public interface Params_HeaderApi {
    * apiParamsHeaderCollisionGet.
    *
    * @param version  (optional)
-   * @param version  (optional)
+   * @param versionQuery  (optional)
    * @return String
    */
   @GET
   @Path("/collision")
   @Produces(MediaType.TEXT_PLAIN)
   @APIResponseSchema(String.class)
-  String apiParamsHeaderCollisionGet(@HeaderParam("version") String versionHeader, @QueryParam("version") String version);
+  String apiParamsHeaderCollisionGet(@HeaderParam("version") String version, @QueryParam("version") String versionQuery);
 
   /**
    * apiParamsHeaderInvalidNameDashesGet.

--- a/modules/generator/src/test/java/mada/tests/e2e/api/params/header/api/Params_HeaderApi.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/params/header/api/Params_HeaderApi.java
@@ -42,6 +42,19 @@ public interface Params_HeaderApi {
   String apiParamsHeaderBooleanWrapperGet(@HeaderParam("flag") boolean flag);
 
   /**
+   * apiParamsHeaderCollisionGet.
+   *
+   * @param version  (optional)
+   * @param version  (optional)
+   * @return String
+   */
+  @GET
+  @Path("/collision")
+  @Produces(MediaType.TEXT_PLAIN)
+  @APIResponseSchema(String.class)
+  String apiParamsHeaderCollisionGet(@HeaderParam("version") String versionHeader, @QueryParam("version") String version);
+
+  /**
    * apiParamsHeaderInvalidNameDashesGet.
    *
    * @param invalidValue

--- a/modules/generator/src/test/java/mada/tests/e2e/api/params/header/openapi.yaml
+++ b/modules/generator/src/test/java/mada/tests/e2e/api/params/header/openapi.yaml
@@ -109,3 +109,25 @@ paths:
             text/plain:
               schema:
                 type: string
+
+  # As seen in winget api, header and query param name collisions
+  /api/params/header/collision:
+    get:
+      tags:
+      - Params Header
+      parameters:
+      - name: version
+        in: header
+        schema:
+          type: string
+      - name: version
+        in: query
+        schema:
+          type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            text/plain:
+              schema:
+                type: string

--- a/modules/model/src/main/java/dk/mada/jaxrs/model/api/Parameter.java
+++ b/modules/model/src/main/java/dk/mada/jaxrs/model/api/Parameter.java
@@ -34,4 +34,18 @@ public interface Parameter {
 
     /** {@return true if the parameter is a form parameter, otherwise false} */
     boolean isFormParam();
+
+    /** {@return an extension of the name used for conflict handling} */
+    default String nameConflictSuffixExt() {
+        if (isHeaderParam()) {
+            return "Header";
+        }
+        if (isPathParam()) {
+            return "Path";
+        }
+        if (isQueryParam()) {
+            return "Query";
+        }
+        return "Form";
+    }
 }


### PR DESCRIPTION
The parameters are named in separate (spec) namespaces it appears.
But the generated Java methods parameters are in a single namespace, so append parameter type to name to resolve conflicts.
This fixes #1043 