### PR TITLE
Record builder fields must all be nullable

### DIFF
--- a/modules/generator/src/main/resources/templates/record.mustache
+++ b/modules/generator/src/main/resources/templates/record.mustache
@@ -89,7 +89,7 @@ public record {{classname}}{{#parent}} extends {{{.}}}{{/parent}}{{#madaDto.impl
   {{#madaDto.isRecordBuilder}}
     public static class Builder {
   {{#vars}}
-      private {{>nullablePrefix}}{{{datatypeWithEnum}}} {{name}};
+      private {{#madaDto.isJspecify}}@Nullable {{/madaDto.isJspecify}}{{{datatypeWithEnum}}} {{name}};
   {{/vars}}
 
       public static Builder of() {

--- a/modules/generator/src/test/java/mada/fixture/TestIterator.java
+++ b/modules/generator/src/test/java/mada/fixture/TestIterator.java
@@ -50,7 +50,7 @@ class TestIterator {
 
         // Replace with partial test name (or empty to run all tests)
         // Handy when working on a single test
-        String testNameContains = "allof_single";
+        String testNameContains = "record/builders_all";
 //        String testNameContains = "params/body/";
 //        String testNameContains = "additional_properties";
 //        String testNameContains = "e2e/specs/v3_0";

--- a/modules/generator/src/test/java/mada/tests/e2e/opts/generator/record/builders_all/dto/CyclicB.java
+++ b/modules/generator/src/test/java/mada/tests/e2e/opts/generator/record/builders_all/dto/CyclicB.java
@@ -8,8 +8,11 @@
 
 package mada.tests.e2e.opts.generator.record.builders_all.dto;
 
+import java.util.Objects;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -20,10 +23,24 @@ public record CyclicB(
   @JsonbProperty("a")
   @Valid
   @Nullable
-  CyclicA a) {
+  CyclicA a,
 
+  @JsonbProperty("fieldIsNotNullable")
+  @Schema(required = true)
+  @NotNull
+  String fieldIsNotNullable,
+
+  @JsonbProperty("fieldIsNullable")
+  @Nullable
+  String fieldIsNullable) {
+
+    public CyclicB {
+      Objects.requireNonNull(fieldIsNotNullable, "Property fieldIsNotNullable is required, cannot be null");
+    }
     public static class Builder {
       private @Nullable CyclicA a;
+      private @Nullable String fieldIsNotNullable;
+      private @Nullable String fieldIsNullable;
 
       public static Builder of() {
         return new Builder();
@@ -32,6 +49,8 @@ public record CyclicB(
       public static Builder of(CyclicB from) {
         Builder o = new Builder();
         o.a = from.a();
+        o.fieldIsNotNullable = from.fieldIsNotNullable();
+        o.fieldIsNullable = from.fieldIsNullable();
         return o;
       }
 
@@ -40,9 +59,21 @@ public record CyclicB(
         return this;
       }
 
+      public Builder fieldIsNotNullable(String fieldIsNotNullable) {
+        this.fieldIsNotNullable = fieldIsNotNullable;
+        return this;
+      }
+
+      public Builder fieldIsNullable(@Nullable String fieldIsNullable) {
+        this.fieldIsNullable = fieldIsNullable;
+        return this;
+      }
+
       public CyclicB build() {
         return new CyclicB(
-                 a
+                 a,
+                 fieldIsNotNullable,
+                 fieldIsNullable
                );
       }
     }

--- a/modules/generator/src/test/java/mada/tests/e2e/opts/generator/record/builders_all/openapi.yaml
+++ b/modules/generator/src/test/java/mada/tests/e2e/opts/generator/record/builders_all/openapi.yaml
@@ -37,6 +37,12 @@ components:
           $ref: '#/components/schemas/CyclicB'
     CyclicB:
       type: object
+      required:
+        - fieldIsNotNullable
       properties:
         a:
           $ref: '#/components/schemas/CyclicA'
+        fieldIsNullable:
+          type: string
+        fieldIsNotNullable:
+          type: string


### PR DESCRIPTION
The builder object is born with all fields null, so they must be nullable.
(fixes #1038)